### PR TITLE
Add the payment source for solidus square

### DIFF
--- a/app/models/solidus_square/payment_source.rb
+++ b/app/models/solidus_square/payment_source.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusSquare
+  class PaymentSource < SolidusSupport.payment_source_parent_class
+    self.table_name = 'solidus_square_payment_sources'
+
+    validates :token, presence: true
+  end
+end

--- a/db/migrate/20211019131838_create_solidus_square_payment_sources.rb
+++ b/db/migrate/20211019131838_create_solidus_square_payment_sources.rb
@@ -1,0 +1,12 @@
+class CreateSolidusSquarePaymentSources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :solidus_square_payment_sources do |t|
+      t.string :token
+      t.integer :payment_method_id, index: true
+
+      t.timestamps
+    end
+
+    add_foreign_key :solidus_square_payment_sources, :spree_payment_methods, column: :payment_method_id
+  end
+end

--- a/solidus_square.gemspec
+++ b/solidus_square.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'square.rb'
 
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'shoulda-matchers', '~> 4.5.1'
   spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
   spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'webmock', '~> 3.14'

--- a/spec/models/solidus_square/payment_source_spec.rb
+++ b/spec/models/solidus_square/payment_source_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe SolidusSquare::PaymentSource, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:token) }
+  end
+end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+require "shoulda/matchers"
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
To keep track of the checkout with Square and the Payment in Solidus we
need a model that will be the Source of the Payment when payed with the
Square PaymentMethod.

fix #19 