### PR TITLE
Add location Id as a preference to payment method

### DIFF
--- a/app/models/solidus_square/payment_method.rb
+++ b/app/models/solidus_square/payment_method.rb
@@ -4,6 +4,7 @@ module SolidusSquare
   class PaymentMethod < SolidusSupport.payment_method_parent_class
     preference :access_token, :string
     preference :environment, :string
+    preference :location_id, :string
 
     def gateway_class
       ::SolidusSquare::Gateway


### PR DESCRIPTION
Add the location id preference to the payment method as this is needed for the payment flow.

fix #22