### PR TITLE
Checkout api endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ RSpec/MultipleExpectations:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ To activate the Square hosted checkout workflow, simply uncomment the endpoint i
 
 and create a button to bring the user at that page, or call the API to start the checkout Flow.
 
+When the Square hosted checkout finish, Square will redirect you automatically to the confirm page of the Solidus frontend.
+
+If you are not using the Solidus frontend please specify your custom URL in the PaymentMethod `redirect_url` preferences in the admin panel.
+
 <!-- Explain how to use your extension once it's been installed. -->
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ SolidusSquare::PaymentMethod.new(
 
 ## Usage
 
+To activate the Square hosted checkout workflow, simply uncomment the endpoint in the `config/routes.rb` file,
+
+and create a button to bring the user at that page, or call the API to start the checkout Flow.
+
 <!-- Explain how to use your extension once it's been installed. -->
 
 ## Development

--- a/app/controllers/solidus_square/callback_actions_controller.rb
+++ b/app/controllers/solidus_square/callback_actions_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SolidusSquare
+  class CallbackActionsController < SolidusSquare::BaseController
+    def square_checkout
+      checkout_page_url = SolidusSquare::Gateway.new(
+        access_token: SolidusSquare.config.square_access_token,
+        environment: SolidusSquare.config.square_environment,
+        location_id: SolidusSquare.config.square_location_id
+      ).checkout(order, redirect_url)[:checkout_page_url]
+
+      respond_to do |format|
+        format.html { redirect_to checkout_page_url }
+        format.json { render json: { redirect_url: checkout_page_url } }
+      end
+    end
+
+    private
+
+    def order
+      @order ||= Spree::Order.find_by(number: params[:order_number])
+    end
+
+    def redirect_url
+      ::SolidusSquare::PaymentMethod.active.first&.preferred_redirect_url
+    end
+  end
+end

--- a/app/models/solidus_square/payment_method.rb
+++ b/app/models/solidus_square/payment_method.rb
@@ -5,6 +5,7 @@ module SolidusSquare
     preference :access_token, :string
     preference :environment, :string
     preference :location_id, :string
+    preference :redirect_url, :string
 
     def gateway_class
       ::SolidusSquare::Gateway

--- a/app/services/solidus_square/base.rb
+++ b/app/services/solidus_square/base.rb
@@ -12,8 +12,16 @@ module SolidusSquare
       new(*args).call
     end
 
+    private
+
     def idempotency_key
       SecureRandom.uuid
+    end
+
+    def handle_square_result(square_result)
+      return yield(square_result) if square_result.success?
+
+      raise ServerError, square_result.errors.to_json
     end
   end
 end

--- a/app/services/solidus_square/checkouts/create.rb
+++ b/app/services/solidus_square/checkouts/create.rb
@@ -26,8 +26,9 @@ module SolidusSquare
       private
 
       def create_checkout
-        result = client.checkout.create_checkout(construct_checkout)
-        result.data&.checkout
+        handle_square_result(client.checkout.create_checkout(construct_checkout)) do |result|
+          result.data&.checkout
+        end
       end
 
       def construct_checkout

--- a/app/services/solidus_square/checkouts/create.rb
+++ b/app/services/solidus_square/checkouts/create.rb
@@ -39,7 +39,7 @@ module SolidusSquare
               order: {
                 location_id: location_id,
                 reference_id: order.number,
-                customer_id: order.user_id,
+                customer_id: order.user_id.to_s,
                 line_items: [{
                   name: 'Order total',
                   quantity: '1',

--- a/app/services/solidus_square/customers/create.rb
+++ b/app/services/solidus_square/customers/create.rb
@@ -23,13 +23,15 @@ module SolidusSquare
       end
 
       def create_customer
-        result = client.customers.create_customer(construct_customer)
-        result.data&.customer
+        handle_square_result(client.customers.create_customer(construct_customer)) do |result|
+          result.data&.customer
+        end
       end
 
       def search_customer
-        result = client.customers.search_customers(construct_search_query)
-        result.data&.customers&.first
+        handle_square_result(client.customers.search_customers(construct_search_query)) do |result|
+          result.data&.customers&.first
+        end
       end
 
       private

--- a/app/services/solidus_square/server_error.rb
+++ b/app/services/solidus_square/server_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SolidusSquare
+  class ServerError < StandardError
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,8 @@
 
 SolidusSquare::Engine.routes.draw do
   # Add your extension routes here
-  get '/customers', to: '/solidus_square/customers#index'
+  get 'customers', to: '/solidus_square/customers#index'
+
+  # Uncomment this line to activate the endpoint for the Square hosted checkout workflow.
+  # post 'square_checkout', to: '/solidus_square/callback_actions#square_checkout'
 end

--- a/lib/generators/solidus_square/install/templates/initializer.rb
+++ b/lib/generators/solidus_square/install/templates/initializer.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
+SolidusSquare.configure do |config|
+  config.square_access_token = ENV['SQUARE_ACCESS_TOKEN']
+  config.square_environment = ENV['SQUARE_ENVIRONMENT']
+  config.square_location_id = ENV['SQUARE_LOCATION_ID']
+end
+
 Spree::Config.configure do |config|
   config.static_model_preferences.add(
     SolidusSquare::PaymentMethod,
     'square_credentials', {
-      access_token: ENV['SQUARE_ACCESS_TOKEN'],
-      environment: ENV['SQUARE_ENVIRONMENT'],
+      access_token: SolidusSquare.config.square_access_token,
+      environment: SolidusSquare.config.square_environment
     }
   )
 end

--- a/lib/solidus_square/configuration.rb
+++ b/lib/solidus_square/configuration.rb
@@ -5,7 +5,7 @@ module SolidusSquare
     # Define here the settings for this extension, e.g.:
     #
     # attr_accessor :my_setting
-    attr_accessor :square_access_token, :square_environment
+    attr_accessor :square_access_token, :square_environment, :square_location_id
   end
 
   class << self

--- a/lib/solidus_square/testing_support/factories.rb
+++ b/lib/solidus_square/testing_support/factories.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :square_payment_method, class: SolidusSquare::PaymentMethod do
+    name { 'Square' }
+  end
 end

--- a/spec/controllers/solidus_square/callback_actions_controller_spec.rb
+++ b/spec/controllers/solidus_square/callback_actions_controller_spec.rb
@@ -17,11 +17,6 @@ RSpec.describe 'SolidusSquare::CallbackActionsController', type: :request do
     let(:payment_method) { create(:square_payment_method) }
 
     before do
-      order.currency = "EUR"
-      order.save
-      allow(SolidusSquare.config).to receive(:square_access_token).and_return(ENV['SQUARE_ACCESS_TOKEN'])
-      allow(SolidusSquare.config).to receive(:square_environment).and_return(ENV['SQUARE_ENVIRONMENT'])
-      allow(SolidusSquare.config).to receive(:square_location_id).and_return(ENV['SQUARE_LOCATION_ID'])
       payment_method.preferred_redirect_url = "https://github.com"
       payment_method.save!
     end
@@ -33,6 +28,7 @@ RSpec.describe 'SolidusSquare::CallbackActionsController', type: :request do
 
       it "has http status 302" do
         expect(response.status).to eq(302)
+        expect(response.location).to match %r/https:\/\/connect.squareupsandbox.com\/v2\/checkout\?/
       end
     end
 

--- a/spec/controllers/solidus_square/callback_actions_controller_spec.rb
+++ b/spec/controllers/solidus_square/callback_actions_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'SolidusSquare::CallbackActionsController', type: :request do
+  around do |test|
+    Rails.application.routes.draw do
+      post 'square_checkout', to: 'solidus_square/callback_actions#square_checkout'
+      mount Spree::Core::Engine, at: '/'
+    end
+    test.run
+    Rails.application.reload_routes!
+  end
+
+  describe '#square_checkout', vcr: true do
+    let(:order) { create(:order_with_line_items) }
+    let(:payment_method) { create(:square_payment_method) }
+
+    before do
+      order.currency = "EUR"
+      order.save
+      allow(SolidusSquare.config).to receive(:square_access_token).and_return(ENV['SQUARE_ACCESS_TOKEN'])
+      allow(SolidusSquare.config).to receive(:square_environment).and_return(ENV['SQUARE_ENVIRONMENT'])
+      allow(SolidusSquare.config).to receive(:square_location_id).and_return(ENV['SQUARE_LOCATION_ID'])
+      payment_method.preferred_redirect_url = "https://github.com"
+      payment_method.save!
+    end
+
+    context "when respond to html", vcr: true do
+      before do
+        post square_checkout_path(order_number: order.number)
+      end
+
+      it "has http status 302" do
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context "when respond to json", vcr: true do
+      before do
+        post square_checkout_path(order_number: order.number, format: :json)
+      end
+
+      it "returns the checkout_page_url" do
+        expect(JSON.parse(response.body)).to include("redirect_url")
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_html/has_http_status_302.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_html/has_http_status_302.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/locations/LOCATION_ID/checkouts
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"6329e49c-0cc1-49a5-a4fa-223ddff2b6e8","order":{"order":{"location_id":"LOCATION_ID","reference_id":"R155395364","customer_id":"1","line_items":[{"name":"Order
+        total","quantity":"1","base_price_money":{"amount":11000,"currency":"EUR"}}]}},"pre_populate_buyer_email":"email1@example.com","redirect_url":"https://github.com"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Speleo-Traceid:
+      - QBPWSZXDBbTWc
+      X-Xss-Protection:
+      - 1; mode=block
+      Date:
+      - Wed, 27 Oct 2021 09:24:18 GMT
+      Content-Length:
+      - '588'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAA/7ySX1PaQBTFv4pzn1dJIiBkxmlFmdpqtVVUoO3sLJsbWE12l/2DgMN37yyxPljHgYf2KQ/5nXvPOXefgE+QPyjvIH0CkUEKx52j627nlp/jqHW2POlOOsUwOu2f1D91gbzgVLMxUm8KSGHinLZprcaVlMjdnp16ZtBry2Q2UvM9rsraLKn9kX7gh+/s+OmjKGkWh+ffB2f9/pde867R6AMBZh9orgy1E6G1kGPKssygtZDmrLBIQBukWmlfMId05BdoKJZMBIPrb/wR56zUBQY/QMBgJgxy9yrEWLiJHz0zymRoXprJ57xzPLg5uDruN29M+77ZuCvyi1Y7GTQHAyBQKM6cUJKu6dcBDOZoUHKsfl/FjcZ+u7HfrAMBq7zhGBZJViKkcF1Vt5Mrs2Onkcj07qJcnuV15qePi+X48iBJVO/2dAwrAtxbp0o01eA4OBESqXBYWkh/PIFf/3gcDqNId5b6ot45Gs3ifHCvwkmfV16GrDtOOVYAgaln0gm3eB4YZlG30AH83Ot+BQIjZpFqIzjSUklcBPesVF46SOM4iqJgzITEYUj35ipYnTEjqo7Wi7bWj42yllpWoN1CVe1ybP635h0+E5YHaCvRpqZWvwhIdLTCbFBsN4DA5nm2TSL0hqRFMwsH5BNmxm/c8a3gBLhB5jCjzEEKSZTEu3G0mxz0onaa1NO4tVffbw2BgNfZRpx1zK1f8LfuBRCYobFCSUjjbY/yX1/K5i1X/L/pegir1e8AAAD//8lKGJgFBgAA
+  recorded_at: Wed, 27 Oct 2021 09:24:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_html/has_http_status_302.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_html/has_http_status_302.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://connect.squareupsandbox.com/v2/locations/LOCATION_ID/checkouts
     body:
       encoding: UTF-8
-      string: '{"idempotency_key":"6329e49c-0cc1-49a5-a4fa-223ddff2b6e8","order":{"order":{"location_id":"LOCATION_ID","reference_id":"R155395364","customer_id":"1","line_items":[{"name":"Order
-        total","quantity":"1","base_price_money":{"amount":11000,"currency":"EUR"}}]}},"pre_populate_buyer_email":"email1@example.com","redirect_url":"https://github.com"}'
+      string: '{"idempotency_key":"79ca40d7-d133-48ed-8f94-6dfc3935b45b","order":{"order":{"location_id":"LOCATION_ID","reference_id":"R480216419","customer_id":"1","line_items":[{"name":"Order
+        total","quantity":"1","base_price_money":{"amount":11000,"currency":"USD"}}]}},"pre_populate_buyer_email":"email1@example.com","redirect_url":"https://github.com"}'
     headers:
       Accept:
       - application/json
@@ -42,18 +42,18 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Speleo-Traceid:
-      - QBPWSZXDBbTWc
+      - McMADWgHfYRQg
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Wed, 27 Oct 2021 09:24:18 GMT
+      - Wed, 27 Oct 2021 21:16:37 GMT
       Content-Length:
-      - '588'
+      - '585'
       Strict-Transport-Security:
       - max-age=631152000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAA/7ySX1PaQBTFv4pzn1dJIiBkxmlFmdpqtVVUoO3sLJsbWE12l/2DgMN37yyxPljHgYf2KQ/5nXvPOXefgE+QPyjvIH0CkUEKx52j627nlp/jqHW2POlOOsUwOu2f1D91gbzgVLMxUm8KSGHinLZprcaVlMjdnp16ZtBry2Q2UvM9rsraLKn9kX7gh+/s+OmjKGkWh+ffB2f9/pde867R6AMBZh9orgy1E6G1kGPKssygtZDmrLBIQBukWmlfMId05BdoKJZMBIPrb/wR56zUBQY/QMBgJgxy9yrEWLiJHz0zymRoXprJ57xzPLg5uDruN29M+77ZuCvyi1Y7GTQHAyBQKM6cUJKu6dcBDOZoUHKsfl/FjcZ+u7HfrAMBq7zhGBZJViKkcF1Vt5Mrs2Onkcj07qJcnuV15qePi+X48iBJVO/2dAwrAtxbp0o01eA4OBESqXBYWkh/PIFf/3gcDqNId5b6ot45Gs3ifHCvwkmfV16GrDtOOVYAgaln0gm3eB4YZlG30AH83Ot+BQIjZpFqIzjSUklcBPesVF46SOM4iqJgzITEYUj35ipYnTEjqo7Wi7bWj42yllpWoN1CVe1ybP635h0+E5YHaCvRpqZWvwhIdLTCbFBsN4DA5nm2TSL0hqRFMwsH5BNmxm/c8a3gBLhB5jCjzEEKSZTEu3G0mxz0onaa1NO4tVffbw2BgNfZRpx1zK1f8LfuBRCYobFCSUjjbY/yX1/K5i1X/L/pegir1e8AAAD//8lKGJgFBgAA
-  recorded_at: Wed, 27 Oct 2021 09:24:18 GMT
+        H4sIAAAAAAAA/7yS308aTxTF/xVzn0eZXRF1E/P9AlJjKmpFWrFtJsPsBSbszozzYwsh/O/NsOqDNQYe2qd92M+595xzZwVihmKug4dsBTKHDLqd9qB3RR+q3jyfy2FLPsj5uH/Z6V/OgbzizPApsmALyGDmvXFZoyG0Uij8gXsK3GIwjqt8rBcHQpeNKm28SP8TZx/s+BEoTVvF2dXF9V3zsDsafHoYfQUC3M3ZRFvmZtIYqaaM57lF5yCb8MIhAWORGW1CwT2ycViiZVhyGQ1uvsn/uOClKTD6AQIWc2lR+DchptLPwviZ0TZH+9pMPrgKR9Qvzkf+21110vO5alfXQ3pzgY8jIFBowb3Uim3otwEsTtCiElj/vmue0DRpNZNTIOB0sALjIsVLhAwGdXV7E2333BOVudlv92Vim18mRyNJh5+nKnQuwrINawIiOK9LtPXgJDqRCpn0WDrIvq8gbH70lqe/ys7QeHXbVaI46lb20HSBvOy8iWH3vPa8AAJPgSsv/fJ5YhzG/NJE8PK+1wcCY+6QGSsFslIrXEb7vNRBeciShFIandkYOQ4ZDs6j14pbWZe0WbSzfmq1c8zxAt0OqnqX54s/NR/wuXQiQjuJtjW1/klAoWc15qJitwEEts+zaxJptiQd2ioeUMy4nb5zx/eCExAWuceccQ8ZpDRN9hO6nx7fp0mWtLLD44NmSh+BQDD5Vpzz3G9e8G3vGghUaJ3UCrJk16P805eyfcs1/3e6foT1+ncAAAD//zjR4EEGBgAA
+  recorded_at: Wed, 27 Oct 2021 21:16:37 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_json/returns_the_checkout_page_url.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_json/returns_the_checkout_page_url.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://connect.squareupsandbox.com/v2/locations/LOCATION_ID/checkouts
     body:
       encoding: UTF-8
-      string: '{"idempotency_key":"02f4ed38-86e0-42a2-9720-89522d564e87","order":{"order":{"location_id":"LOCATION_ID","reference_id":"R942823433","customer_id":"1","line_items":[{"name":"Order
-        total","quantity":"1","base_price_money":{"amount":11000,"currency":"EUR"}}]}},"pre_populate_buyer_email":"email2@example.com","redirect_url":"https://github.com"}'
+      string: '{"idempotency_key":"bc98a213-6325-474e-9f26-538bc13b6f0c","order":{"order":{"location_id":"LOCATION_ID","reference_id":"R791158962","customer_id":"1","line_items":[{"name":"Order
+        total","quantity":"1","base_price_money":{"amount":11000,"currency":"USD"}}]}},"pre_populate_buyer_email":"email2@example.com","redirect_url":"https://github.com"}'
     headers:
       Accept:
       - application/json
@@ -42,18 +42,18 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Speleo-Traceid:
-      - EPHYFMHCgXZMe
+      - RYhMHHkYCFQgC
       X-Xss-Protection:
       - 1; mode=block
       Date:
-      - Wed, 27 Oct 2021 09:24:20 GMT
+      - Wed, 27 Oct 2021 21:16:38 GMT
       Content-Length:
-      - '591'
+      - '585'
       Strict-Transport-Security:
       - max-age=631152000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAA/7ySX28aOxDFv0o0z07YXQh/Voruzc0lIsm9JSU0JbSVZbyz4LJrG/+hQMR3r8wmeUijCB7aJz/4d2bOmZlH4DPkc+UdpI8gMkjh4p/zu+717QPvKN6+6tfno3/ZmMe9xeZ/IC841WyK1JsCUpg5p21aq3ElJXJ3YheeGfTaMplN1OqEq7K2TGrP0r/42Ts9vvooSprF2X8fH25Go+th8/Pp6QgIMDunuTLUzoTWQk4pyzKD1kKas8IiAW2QaqV9wRzSiV+joVgyEQzu3uRvXLFSFxj8AAGDmTDI3asQU+FmfvLEKJOheZnMsN7/zsbtdtSaXxf+9C4fXOb3zUY+WGXjByBQKM6cUJLu6NcBDOZoUHKsvgedRtJO6o16HQhY5Q3H0EiyEiGFu2p0R7kyR3YRiUwfr8vNTd5gfvFjvZn2W0mihve9KWwJcG+dKtFUhePgREikwmFpIf3yCH73cW5lNp5n5WWx6U1akp3zbm91AeS5Zz+EPXLKsQIILDyTTrj1U8VQjLq1DuDVsBtOYcIsUm0ER1oqietgn5XKSwdpHEdRFJyZEDkU6X4aBK9LZkQ1pF2jg/VTo6yllhVoD1BVvRxb/ap5h8+E5QE6SLSvqe03AhIdrTAbFIcVILB/nkOTCL0nadEswwL5jJnpG3t8KzgBbpA5zChzkEISJfFxHB0nrWHUSZNGGndOOs36GAh4ne3FWcfc7oJvux+AwBKNFUpCGh+6lD96KftPueJ/x6yTaAzb7c8AAAD//z/pQZgGBgAA
-  recorded_at: Wed, 27 Oct 2021 09:24:20 GMT
+        H4sIAAAAAAAA/7ySX08aQRTFv4q5z6PsLqK4iWmRKjUqtSBaaJvJMHuBCbszw/whUMN3b4alPlhj2If2aR/2d+4959x5Bj5DPlfeQfoMIoMU2het/mW710muH/PO3K27D6PFTbRqsd4QyAtONZsi9SaHFGbOaZvWalxJidwd2YVnBr22TGZjtTriqqgtk9of6Qd+/s6OHz6KkpP8/LbT7R3X28P+1bfhIxBgdk4nylA7E1oLOaUsywxaC+mE5RYJaINUK+1z5pCO/RoNxYKJYHD7TT7iihU6x+AHCBjMhEHuXoWYCjfz4x2jTIbmpZlld9B+nDQHn097tqi78XGE87ydP9nb21HoJlecOaEk3dKvAxicoEHJsfzdOz2L40bz7CQBAlZ5wzEskqxASKFfVncwUebALiKR6cPWnYjN8ddJYyiiwc1U+ouOX7dgQ4B761SBphwcBydCIhUOCwvp92fw2x+N5moQreLW1ey+/YvVn7r8vhdC7lZ+CVkPnHIsBwILz6QTbr0bGGZRt9YBvH64vAMCY2aRaiM40kJJXAf3rFBeOkjjOIqiYMyExGHIoP8pWF0yI8qOtosq66dGWUsty9FWUJW7HFv9rXmHz4TlAaok2tfU5icBiY6WmA2KagMI7J+nahKh9yQtmmU4IJ8xM33jjm8FJ8ANMocZZQ5SSKIkPoyjw+T0IYnT+CStN48a9WQEBLzO9uKsY277gu8vu0BgicYKJSGNqx7lv76U/Vsu+X/T9Qg2m98BAAD//0S7k1cFBgAA
+  recorded_at: Wed, 27 Oct 2021 21:16:38 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_json/returns_the_checkout_page_url.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_CallbackActionsController/_square_checkout/when_respond_to_json/returns_the_checkout_page_url.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/locations/LOCATION_ID/checkouts
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"02f4ed38-86e0-42a2-9720-89522d564e87","order":{"order":{"location_id":"LOCATION_ID","reference_id":"R942823433","customer_id":"1","line_items":[{"name":"Order
+        total","quantity":"1","base_price_money":{"amount":11000,"currency":"EUR"}}]}},"pre_populate_buyer_email":"email2@example.com","redirect_url":"https://github.com"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Speleo-Traceid:
+      - EPHYFMHCgXZMe
+      X-Xss-Protection:
+      - 1; mode=block
+      Date:
+      - Wed, 27 Oct 2021 09:24:20 GMT
+      Content-Length:
+      - '591'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAA/7ySX28aOxDFv0o0z07YXQh/Voruzc0lIsm9JSU0JbSVZbyz4LJrG/+hQMR3r8wmeUijCB7aJz/4d2bOmZlH4DPkc+UdpI8gMkjh4p/zu+717QPvKN6+6tfno3/ZmMe9xeZ/IC841WyK1JsCUpg5p21aq3ElJXJ3YheeGfTaMplN1OqEq7K2TGrP0r/42Ts9vvooSprF2X8fH25Go+th8/Pp6QgIMDunuTLUzoTWQk4pyzKD1kKas8IiAW2QaqV9wRzSiV+joVgyEQzu3uRvXLFSFxj8AAGDmTDI3asQU+FmfvLEKJOheZnMsN7/zsbtdtSaXxf+9C4fXOb3zUY+WGXjByBQKM6cUJLu6NcBDOZoUHKsvgedRtJO6o16HQhY5Q3H0EiyEiGFu2p0R7kyR3YRiUwfr8vNTd5gfvFjvZn2W0mihve9KWwJcG+dKtFUhePgREikwmFpIf3yCH73cW5lNp5n5WWx6U1akp3zbm91AeS5Zz+EPXLKsQIILDyTTrj1U8VQjLq1DuDVsBtOYcIsUm0ER1oqietgn5XKSwdpHEdRFJyZEDkU6X4aBK9LZkQ1pF2jg/VTo6yllhVoD1BVvRxb/ap5h8+E5QE6SLSvqe03AhIdrTAbFIcVILB/nkOTCL0nadEswwL5jJnpG3t8KzgBbpA5zChzkEISJfFxHB0nrWHUSZNGGndOOs36GAh4ne3FWcfc7oJvux+AwBKNFUpCGh+6lD96KftPueJ/x6yTaAzb7c8AAAD//z/pQZgGBgAA
+  recorded_at: Wed, 27 Oct 2021 09:24:20 GMT
+recorded_with: VCR 6.0.0

--- a/spec/services/solidus_square/checkouts/create_spec.rb
+++ b/spec/services/solidus_square/checkouts/create_spec.rb
@@ -18,9 +18,22 @@ describe ::SolidusSquare::Checkouts::Create do
   let(:redirect_url) { 'https://shop.com/process' }
   let(:client) { instance_double(Square::Client, checkout: checkout_api) }
   let(:checkout_api) { instance_double(Square::CheckoutApi, create_checkout: checkout_response) }
-  let(:checkout_response) { instance_double(Square::ApiResponse, data: OpenStruct.new(checkout: { 'id' => 111 })) }
+  let(:checkout_response) do
+    instance_double(Square::ApiResponse, success?: true, data: OpenStruct.new(checkout: { 'id' => 111 }))
+  end
 
   it 'returns checkout data' do
     expect(service['id']).to eq 111
+  end
+
+  context 'when the server fails with an error' do
+    let(:error_hash) { [{ key: :value }] }
+    let(:checkout_response) do
+      instance_double(Square::ApiResponse, success?: false, errors: error_hash)
+    end
+
+    it 'raise a server exception' do
+      expect { service }.to raise_error(SolidusSquare::ServerError, error_hash.to_json)
+    end
   end
 end

--- a/spec/support/square.rb
+++ b/spec/support/square.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+SolidusSquare.configure do |config|
+  config.square_environment = 'sandbox'
+  config.square_access_token = ENV['SQUARE_ACCESS_TOKEN']
+  config.square_location_id = ENV['SQUARE_LOCATION_ID'] || 'LOCATION'
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -11,7 +11,19 @@ VCR.configure do |config|
   config.allow_http_connections_when_no_cassette = false
 
   config.filter_sensitive_data('<BEARER_TOKEN>') do |interaction|
-    interaction.request.headers['Authorization'].sub('Bearer ', '')
+    interaction.request.headers['Authorization']&.first
+  end
+
+  config.filter_sensitive_data('LOCATION_ID') do |interaction|
+    interaction.request.body.match(SolidusSquare.config.square_location_id)
+  end
+
+  config.before_record do |interaction|
+    interaction.request.uri.sub!(SolidusSquare.config.square_location_id, 'LOCATION_ID')
+  end
+
+  config.before_playback do |interaction|
+    interaction.request.uri.sub!('LOCATION_ID', SolidusSquare.config.square_location_id)
   end
 
   # Let's you set default VCR record mode with VCR_RECORDE_MODE=all for re-recording


### PR DESCRIPTION
In order to start the Square checkout flow, I had to create a CallbackActionsController which will call the create_checkout endpoint and retrieve the correct URL to be redirected to as the checkout flow will be done completely through Square we also should give the redirect_url when calling the create_checkout endpoint from Square.

Add the redirect_url preferences in order to give a custom redirect_url when not using the solidus_frontend.

fix #26 