### PR TITLE
Lock Shoulda-matchers to 4.5

### DIFF
--- a/solidus_square.gemspec
+++ b/solidus_square.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'square.rb'
 
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'shoulda-matchers', '~> 4.5.1'
+  spec.add_development_dependency 'shoulda-matchers', '~> 4.5'
   spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
   spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'webmock', '~> 3.14'


### PR DESCRIPTION
`~> 4.5.1` Locks shoulda-matchers to 4.5.XX version.
It would be better to let to upgrade the gem when a new minor
version is upgraded.