### PR TITLE
Version to source

### DIFF
--- a/db/migrate/20211111150832_add_version_to_solidus_square_payment_sources.rb
+++ b/db/migrate/20211111150832_add_version_to_solidus_square_payment_sources.rb
@@ -1,0 +1,5 @@
+class AddVersionToSolidusSquarePaymentSources < ActiveRecord::Migration[6.1]
+  def change
+    add_column :solidus_square_payment_sources, :version, :integer
+  end
+end


### PR DESCRIPTION
# Version To Payment Source

The webhooks from square are not in synchronous order, eg. first it would send `payment.updated` and after `payment.created`. 

In order to not overwrite the payment source with older information square provides a version number of the information.

I add a column to the payment source model named: `version`. 

Like this, we can compare the version number every time before we update the payment source with the new incoming data.
 

fix #39 