### PR TITLE
Add capture method

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -14,6 +14,17 @@ module SolidusSquare
       )
     end
 
+    def capture(_amount, _response_code, options)
+      payment = options[:originator]
+      payment_source = payment.source
+      square_payment_id = payment_source.square_payment_id
+      response = capture_payment(square_payment_id)
+
+      payment_source.update!(payment_source_constructor(response))
+
+      ActiveMerchant::Billing::Response.new(true, 'Transaction captured', response, authorization: square_payment_id)
+    end
+
     def create_customer(user, address)
       ::SolidusSquare::Customers::Create.call(client: client, spree_user: user, spree_address: address)
     end
@@ -54,6 +65,10 @@ module SolidusSquare
         client: client,
         payment_id: payment_id
       )
+    end
+
+    def payment_source_constructor(data)
+      SolidusSquare::PaymentSourcePresenter.square_payload(data)
     end
   end
 end

--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -48,5 +48,12 @@ module SolidusSquare
         source_id: source_id
       )
     end
+
+    def capture_payment(payment_id)
+      ::SolidusSquare::Payments::Capture.call(
+        client: client,
+        payment_id: payment_id
+      )
+    end
   end
 end

--- a/app/services/solidus_square/payments/capture.rb
+++ b/app/services/solidus_square/payments/capture.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SolidusSquare
+  module Payments
+    class Capture < ::SolidusSquare::Base
+      def initialize(client:, payment_id:)
+        @client = client
+        @payment_id = payment_id
+
+        super
+      end
+
+      def call
+        complete_payment
+      end
+
+      private
+
+      attr_reader :client, :payment_id
+
+      def complete_payment
+        handle_square_result(client.payments.complete_payment(payment_id: payment_id)) do |result|
+          result.body&.payment
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_square/testing_support/factories.rb
+++ b/lib/solidus_square/testing_support/factories.rb
@@ -4,4 +4,9 @@ FactoryBot.define do
   factory :square_payment_method, class: SolidusSquare::PaymentMethod do
     name { 'Square' }
   end
+
+  factory :square_payment_source, class: SolidusSquare::PaymentSource do
+    token { "token" }
+    square_payment_id { "123" }
+  end
 end

--- a/solidus_square.gemspec
+++ b/solidus_square.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
-  spec.add_dependency 'square.rb'
+  spec.add_dependency 'square.rb', '~> 14.0'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'shoulda-matchers', '~> 4.5'

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_Payments_Capture/_call/captures_a_square_payment.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_Payments_Capture/_call/captures_a_square_payment.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"223730520881584","amount_money":{"amount":123,"currency":"USD"},"source_id":"EXTERNAL","external_details":{"type":"CHECK","source":"Food
+        Delivery Service"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 07 Dec 2021 09:31:10 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '493'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVSSY/aMBS+91cgn2EIYZkZbmmWgSlrJhmWqopM8gRmkthx7LCM+O91WFrUHqqebH2bvufnT8TwIYFUoG7lE5FIHejr7HhwHluuJvb2LCmi+dTcsSw7Ws5kuUBVFHLAAqIAlyaka3qj1tBr2qOnPXebjW5De+i0n5ZKiBMqUxEkNIXDOf8CqGtDb6ocyTmkYUkh/81CpyrKBRYyLwFzPJwMbM+2VE5OJQ8hEAcGJWXPPdsdGQPFxDTEgtA0uDQfvBpTve0N3WnzbKQ8An7lfGdx/HBljyfCeGIvUQ/ep34r671vWo6SCipw/D9VQ8zwisREECgLf0e21fcCYzj2R17gT1TkPWCNZ6Mb5PUnf+vuwLP2RxXBXgBPVasIBCZxfu51ewSzZ5vffr1NiTiURhULYlIAP1TegBdEEaophxAIE0EqkxXw24bRb0LyuEQ3QrC8W6/nmcQcJMtxGq3o/iGkSf0qrTMOBYFd/V9/BDMWk+tu7utfsgPGaSTD8/+x1aaHtmvagTHp/+G8bO7ao5ZnGolWtXbukpV+XKz9pd4f6ePWbLuMduWgavC8tAn6AWnpLF6SrGPgtjPHr1mcHQ2x2MK2aMIo26+tvlx62N+0t6a23nQoOp2+/ARpJ1iODwMAAA==
+  recorded_at: Tue, 07 Dec 2021 09:31:10 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments/BWzyF74R0txEWmvdXQCwpqqzDFPZY/complete
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 07 Dec 2021 09:31:11 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '493'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVSSY/aMBS+91cgn2EIYZkZbmmWgSlrJhmWqopM8gRmkthx7LCM+O91WFrUHqqebH2bvufnT8TwIYFUoG7lE5FIHejr7HhwHluuJvb2LCmi+dTcsSw7Ws5kuUBVFHLAAqIAlyaka3qj1tBr2qOnPXebjW5De+i0n5ZKiBMqUxEkNIXDOf8CqGtDb6ocyTmkYUkh/81CpyrKBRYyLwFzPJwMbM+2VE5OJQ8hEAcGJWXPPdsdGQPFxDTEgtA0uDQfvBpTve0N3WnzbKQ8An7lfGdx/HBljyfCeGIvUQ/ep34r671vWo6SCipw/D9VQ8zwisREECgLf0e21fcCYzj2R17gT1TkPWCNZ6Mb5PUnf+vuwLP2RxXBXgBPVasIBCZxfu51ewSzZ5vffr1NiTiURhULYlIAP1TegBdEEaophxAIE0EqkxXw24bRb0LyuEQ3QrC8W6/nmcQcJMtxGq3o/iGkSf0qrTMOBYFd/V9/BDMWk+tu7utfsgPGaSTD8/+x1aaHtmvagTHp/+G8bO7ao5ZnGolWtXbukpV+XKz9pd4f6ePWbLuMduWgavC8tAn6AWnpLF6SrGPgtjPHr1mcHQ2x2MK2aMIo26+tvlx62N+0t6a23nQoOp2+/ARpJ1iODwMAAA==
+  recorded_at: Tue, 07 Dec 2021 09:31:11 GMT
+recorded_with: VCR 6.0.0

--- a/spec/models/solidus_square/gateway_spec.rb
+++ b/spec/models/solidus_square/gateway_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe SolidusSquare::Gateway do
     end
   end
 
+  describe '#capture_payment' do
+    subject(:capture_payment) { described_instance.capture_payment(12_345) }
+
+    before do
+      allow(SolidusSquare::Payments::Capture).to receive(:call)
+      capture_payment
+    end
+
+    it "calls the SolidusSquare::Payments::Capture service" do
+      expect(SolidusSquare::Payments::Capture).to have_received(:call).with(client: gateway.client, payment_id: 12_345)
+    end
+  end
+
   describe '#create_customer' do
     before do
       allow(::SolidusSquare::Customers::Create).to receive(:call)

--- a/spec/models/solidus_square/gateway_spec.rb
+++ b/spec/models/solidus_square/gateway_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe SolidusSquare::Gateway do
   let(:spree_user) { create(:user_with_addresses) }
   let(:spree_address) { spree_user.addresses.first }
   let(:options) { { access_token: 'abcde', environment: 'sandbox', location_id: 'location' } }
-  let(:described_instance) { described_class.new(options) }
+  let(:gateway) { described_class.new(options) }
 
   describe '#initialize' do
     it 'initialize options and client params' do
-      expect(described_instance.location_id).to eq options[:location_id]
-      expect(described_instance.client).to be_an_instance_of(::Square::Client)
+      expect(gateway.location_id).to eq options[:location_id]
+      expect(gateway.client).to be_an_instance_of(::Square::Client)
     end
   end
 
   describe '#capture_payment' do
-    subject(:capture_payment) { described_instance.capture_payment(12_345) }
+    subject(:capture_payment) { gateway.capture_payment(12_345) }
 
     before do
       allow(SolidusSquare::Payments::Capture).to receive(:call)
@@ -34,13 +34,53 @@ RSpec.describe SolidusSquare::Gateway do
     end
 
     it 'call SolidusSquare Customer Create class' do
-      described_instance.create_customer(spree_user, spree_address)
+      gateway.create_customer(spree_user, spree_address)
 
       expect(::SolidusSquare::Customers::Create).to have_received(:call).with(
-        client: described_instance.client,
+        client: gateway.client,
         spree_user: spree_user,
         spree_address: spree_address
       )
+    end
+  end
+
+  describe "#capture" do
+    subject(:capture) { gateway.capture(nil, nil, gateway_options) }
+
+    let(:payment) { create(:payment) }
+    let(:payment_source) { create(:square_payment_source) }
+    let(:gateway_options) { { originator: payment } }
+    let(:square_response) { square_payment_response }
+    let(:capture_params) do
+      {
+        client: gateway.client,
+        payment_id: payment_source.square_payment_id
+      }
+    end
+    let(:expected_attributes) do
+      {
+        version: 3,
+        avs_status: "AVS_ACCEPTED",
+        expiration_date: "11/2022",
+        last_digits: "9029",
+        card_brand: "MASTERCARD",
+        card_type: "CREDIT",
+        status: "CAPTURED"
+      }
+    end
+
+    before do
+      payment.source = payment_source
+      allow(gateway).to receive(:capture_payment).and_return(square_response)
+      capture
+    end
+
+    it "returns an ActiveMerchant::Billing::Response " do
+      expect(capture).to be_an_instance_of(ActiveMerchant::Billing::Response)
+    end
+
+    it "updates the payment_source" do
+      expect(payment_source).to have_attributes(expected_attributes)
     end
   end
 end

--- a/spec/presenters/solidus_square/payment_source_presenter_spec.rb
+++ b/spec/presenters/solidus_square/payment_source_presenter_spec.rb
@@ -9,24 +9,7 @@ RSpec.describe SolidusSquare::PaymentSourcePresenter do
     {
       data: {
         object: {
-          payment: {
-            id: 123,
-            card_details: {
-              status: "CAPTURED",
-              card: {
-                card_brand: "MASTERCARD",
-                # rubocop:disable Naming/VariableNumber
-                last_4: "9029",
-                # rubocop:enable Naming/VariableNumber
-                exp_month: 11,
-                exp_year: 2022,
-                card_type: "CREDIT"
-              },
-              avs_status: "AVS_ACCEPTED",
-            },
-            version: 3,
-            order_id: 12
-          }
+          payment: square_payment_response
         }
       }
     }

--- a/spec/services/solidus_square/create_payment_service_spec.rb
+++ b/spec/services/solidus_square/create_payment_service_spec.rb
@@ -11,26 +11,7 @@ RSpec.describe SolidusSquare::CreatePaymentService do
   let(:gateway) { SolidusSquare::Gateway.new(options) }
   let!(:order) { create(:order_ready_to_complete, number: "R919717664", state: 'delivery', payment_state: nil) }
   let(:status) { "CAPTURED" }
-  let(:square_response) do
-    {
-      amount_money: {
-        amount: order.total
-      },
-      card_details: {
-        status: status,
-        card: {
-          card_brand: "MASTERCARD",
-          last_4: "9029", # rubocop:disable Naming/VariableNumber
-          exp_month: 11,
-          exp_year: 2022,
-          card_type: "CREDIT"
-        },
-        avs_status: "AVS_ACCEPTED",
-      },
-      order_id: 12,
-      version_token: 12_345
-    }
-  end
+  let(:square_response) { square_payment_response(amount: order.total, status: status) }
 
   before do
     allow(Spree::PaymentMethod).to receive(:find).with(payment_method.id).and_return(payment_method)

--- a/spec/services/solidus_square/payment_sync_service_spec.rb
+++ b/spec/services/solidus_square/payment_sync_service_spec.rb
@@ -17,26 +17,7 @@ RSpec.describe SolidusSquare::PaymentSyncService do
       type: "payment.updated",
       data: {
         object: {
-          payment: {
-            amount_money: {
-              amount: order.total
-            },
-            card_details: {
-              status: "CAPTURED",
-              card: {
-                card_brand: "MASTERCARD",
-                # rubocop:disable Naming/VariableNumber
-                last_4: "9029",
-                # rubocop:enable Naming/VariableNumber
-                exp_month: 11,
-                exp_year: 2022,
-                card_type: "CREDIT"
-              },
-              avs_status: "AVS_ACCEPTED",
-            },
-            order_id: square_order_id,
-            version: 3
-          }
+          payment: square_payment_response(amount: order.total, order_id: square_order_id)
         }
       }
     }

--- a/spec/services/solidus_square/payments/capture_spec.rb
+++ b/spec/services/solidus_square/payments/capture_spec.rb
@@ -1,0 +1,28 @@
+# frozen_String_literal: true
+
+RSpec.describe SolidusSquare::Payments::Capture, type: :request do
+  subject(:capture_payment) {
+    described_class.new(client: client, payment_id: square_payment_id)
+  }
+
+  let(:square_payment_id) { create_square_payment_id_on_sandbox }
+  let(:client) do
+    ::Square::Client.new(
+      access_token: SolidusSquare.config.square_access_token,
+      environment: "sandbox"
+    )
+  end
+
+  describe "#call", vcr: true do
+    let(:expected_attributes) do
+      {
+        id: square_payment_id,
+        status: "COMPLETED"
+      }
+    end
+
+    it "captures a square payment" do
+      expect(capture_payment.call).to include(expected_attributes)
+    end
+  end
+end

--- a/spec/support/square.rb
+++ b/spec/support/square.rb
@@ -85,4 +85,26 @@ module SquareHelpers
       external_details: external_details
     }
   end
+
+  def square_payment_response(amount: 100, status: "CAPTURED", order_id: 12)
+    {
+      id: 123,
+      amount_money: {
+        amount: amount
+      },
+      card_details: {
+        status: status,
+        card: {
+          card_brand: "MASTERCARD",
+          last_4: "9029", # rubocop:disable Naming/VariableNumber
+          exp_month: 11,
+          exp_year: 2022,
+          card_type: "CREDIT"
+        },
+        avs_status: "AVS_ACCEPTED",
+      },
+      order_id: order_id,
+      version: 3
+    }
+  end
 end


### PR DESCRIPTION
fix #47 

# Add Capture Method On Gateway

When clicking on the capture button in the admin panel was leading to an error.

To fix this I add the `#capture` method in the admin panel, which will make an API call to square to capture the payment.

With the response, it will update the payment_source, and return an `ActiveMerchant::Billing::Response`, so that solidus can complete the payment.