### PR TITLE
Add refund method

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -25,6 +25,14 @@ module SolidusSquare
       ActiveMerchant::Billing::Response.new(true, 'Transaction captured', response, authorization: square_payment_id)
     end
 
+    def credit(amount, response_code, options)
+      square_payment_id = options[:originator].payment.source.square_payment_id
+      response = refund_payment(amount, square_payment_id)
+
+      ActiveMerchant::Billing::Response.new(true, "Transaction Credited with #{amount}", response,
+        authorization: response_code)
+    end
+
     def create_customer(user, address)
       ::SolidusSquare::Customers::Create.call(client: client, spree_user: user, spree_address: address)
     end
@@ -63,6 +71,14 @@ module SolidusSquare
     def capture_payment(payment_id)
       ::SolidusSquare::Payments::Capture.call(
         client: client,
+        payment_id: payment_id
+      )
+    end
+
+    def refund_payment(amount, payment_id)
+      ::SolidusSquare::Refunds::Create.call(
+        client: client,
+        amount: amount,
         payment_id: payment_id
       )
     end

--- a/app/services/solidus_square/refunds/create.rb
+++ b/app/services/solidus_square/refunds/create.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module SolidusSquare
+  module Refunds
+    class Create < ::SolidusSquare::Base
+      def initialize(client:, amount:, payment_id:)
+        @client = client
+        @amount = amount
+        @payment_id = payment_id
+
+        super
+      end
+
+      def call
+        refund_payment
+      end
+
+      private
+
+      attr_reader :client, :amount, :payment_id
+
+      def refund_payment
+        handle_square_result(client.refunds.refund_payment(body: refund_payload)) do |result|
+          result.body&.refund
+        end
+      end
+
+      def refund_payload
+        {
+          payment_id: payment_id,
+          amount_money: amount_money,
+          idempotency_key: idempotency_key
+        }
+      end
+
+      def amount_money
+        {
+          amount: amount,
+          currency: "USD"
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_Refunds_Create/_call/creates_a_refund_with_the_correct_data.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_Refunds_Create/_call/creates_a_refund_with_the_correct_data.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"549047647769381","amount_money":{"amount":123,"currency":"USD"},"source_id":"EXTERNAL","external_details":{"type":"CHECK","source":"Food
+        Delivery Service"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Dec 2021 12:58:22 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '493'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVSW3OiMBR+31/h5FmrUHGsb4g4UlFRod2ys8MEOEPTAsEkoLTjf2/wsuvsPuzsUzLfbb6Tk09U4DqDXKBR6xORWB7INweask5mM5/N0vHTo68p4/7ACMdva/8FtVHEAAuIA9yYkNpTlY6idnoPrqKOtOFIVe80pe9LIc5omYsgoznUp/wzIK+Kei9zSsYgjxoKedsJOrYRF1iUvAGM1cKxTdecyBxOSxZBIOoCGsr87pqbpW5LJqURFoTmwbm5/aivVc1dbNb3JyNlMbALl80NjU4TJ9rqdv06fF/Md7ynkHWC+1MpFVTg9H+qRrjAIUmJINAU/oHMieUG+mLlLd3Ac2TkLTBZPS+vkGs5f+tuwJP2ZxvBQQDLZasYBCYpP/W6PoIxM435r7dpkCmlcWsCKamA1a0tsIpIQjZlEAEpRJCXWQjsumH0myhZ2qCvQhR81O3yXYkZlAXHeRzSw11Es+5F2i0YVAT23X/9EVwUKbns5rb+OTsoGI3L6PR/TLnphbkxzEB3rD+c581denT4rkfisKPxDQnVj5fE81Vrqa76z29+vG8GlYPzxiboO+SNc6kkvnXQS29Ybae25Y6Laug8hZ4N9cNsTG282X4kfLpPoRxQdDx++wLp+nzTDwMAAA==
+  recorded_at: Thu, 09 Dec 2021 12:58:22 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments/ZE651QgHHZrHlBVJZ51B46CbBjQZY/complete
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Dec 2021 12:58:23 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '493'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVSW3OiMBR+31/h5FmrUHGsb4g4UlFRod2ys8MEOEPTAsEkoLTjf2/wsuvsPuzsUzLfbb6Tk09U4DqDXKBR6xORWB7INweask5mM5/N0vHTo68p4/7ACMdva/8FtVHEAAuIA9yYkNpTlY6idnoPrqKOtOFIVe80pe9LIc5omYsgoznUp/wzIK+Kei9zSsYgjxoKedsJOrYRF1iUvAGM1cKxTdecyBxOSxZBIOoCGsr87pqbpW5LJqURFoTmwbm5/aivVc1dbNb3JyNlMbALl80NjU4TJ9rqdv06fF/Md7ynkHWC+1MpFVTg9H+qRrjAIUmJINAU/oHMieUG+mLlLd3Ac2TkLTBZPS+vkGs5f+tuwJP2ZxvBQQDLZasYBCYpP/W6PoIxM435r7dpkCmlcWsCKamA1a0tsIpIQjZlEAEpRJCXWQjsumH0myhZ2qCvQhR81O3yXYkZlAXHeRzSw11Es+5F2i0YVAT23X/9EVwUKbns5rb+OTsoGI3L6PR/TLnphbkxzEB3rD+c581denT4rkfisKPxDQnVj5fE81Vrqa76z29+vG8GlYPzxiboO+SNc6kkvnXQS29Ybae25Y6Laug8hZ4N9cNsTG282X4kfLpPoRxQdDx++wLp+nzTDwMAAA==
+  recorded_at: Thu, 09 Dec 2021 12:58:23 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/refunds
+    body:
+      encoding: UTF-8
+      string: '{"payment_id":"ZE651QgHHZrHlBVJZ51B46CbBjQZY","amount_money":{"amount":123,"currency":"USD"},"idempotency_key":"811d9e40-dfda-40a4-aa83-3e07bba7840a"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Dec 2021 12:58:23 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '272'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAI2Py3KCQBBF9/mK1Kwx5QwPlZ0E5BFiADHE2VADjAZqeGSEsijLf8+Q+AGuuuv26Xu7r4DT49AUQH++gnIqAFuaCsOT42DuMOPTwyo0FO01M6oQH1LXYRmFRsUO5/r4hfOsWkT+bj1+xEnnXuph4bF9vuxtG78BCZx70g/nyTWwtqa7tYVG6nZo+rRuGzr+xf4LooVIlkA+cE6bfBqB/c4ENwl0ZKypWHngPuHf8oLyO0vaJCHfJq/LqHPZpgh8yDR6+gkyZSPQnFPS0yIlUzpAcwRnEM3mqxgiXV3qSH5ZKRALcOiKx0DW5qQv2+ae73vrEKnxexTKlnjl9vQL+Np1vHABAAA=
+  recorded_at: Thu, 09 Dec 2021 12:58:24 GMT
+recorded_with: VCR 6.0.0

--- a/spec/services/solidus_square/refunds/create_spec.rb
+++ b/spec/services/solidus_square/refunds/create_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusSquare::Refunds::Create do
+  subject(:refund_payment) {
+    described_class.new(client: client, amount: amount, payment_id: payment_id)
+  }
+
+  let(:captured_payment) { create_and_capture_payment_on_sandbox }
+  let(:payment_id) { captured_payment[:id] }
+  let(:amount) { captured_payment[:amount_money][:amount] }
+  let(:client) do
+    ::Square::Client.new(
+      access_token: SolidusSquare.config.square_access_token,
+      environment: "sandbox"
+    )
+  end
+
+  describe "#call", vcr: true do
+    let(:expected_attributes) do
+      {
+        amount_money: {
+          amount: amount,
+          currency: "USD"
+        },
+        payment_id: payment_id
+      }
+    end
+
+    it "creates a refund with the correct data" do
+      expect(refund_payment.call).to include(expected_attributes)
+    end
+  end
+end

--- a/spec/support/square.rb
+++ b/spec/support/square.rb
@@ -74,6 +74,15 @@ module SquareHelpers
     client.payments.create_payment(body: create_payment_payload).data.payment[:id]
   end
 
+  def create_and_capture_payment_on_sandbox
+    client = ::Square::Client.new(
+      access_token: SolidusSquare.config.square_access_token,
+      environment: "sandbox"
+    )
+
+    client.payments.complete_payment(payment_id: create_square_payment_id_on_sandbox).body.payment
+  end
+
   def create_payment_payload
     external_details = { type: "CHECK", source: "Food Delivery Service" }
     idempotency_key = rand(1_000_000_000_000_000).to_s


### PR DESCRIPTION
# Credit Method In Gateway

Whenever refunding a payment, solidus calls the credit method in the gateway class.

In order to make a proper refund we need to make an API call to Square, I created a service that will take care of that.

fix #2 