### PR TITLE
Change response code

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -14,29 +14,25 @@ module SolidusSquare
       )
     end
 
-    def capture(_amount, _response_code, options)
-      payment = options[:originator]
-      payment_source = payment.source
-      square_payment_id = payment_source.square_payment_id
-      response = capture_payment(square_payment_id)
+    def capture(_amount, response_code, options)
+      payment_source = options[:originator].source
+      response = capture_payment(response_code)
 
       payment_source.update!(payment_source_constructor(response))
 
-      ActiveMerchant::Billing::Response.new(true, 'Transaction captured', response, authorization: square_payment_id)
+      ActiveMerchant::Billing::Response.new(true, 'Transaction captured', response, authorization: response_code)
     end
 
-    def credit(amount, response_code, options)
-      square_payment_id = options[:originator].payment.source.square_payment_id
-      response = refund_payment(amount, square_payment_id)
+    def credit(amount, response_code, _options)
+      response = refund_payment(amount, response_code)
 
       ActiveMerchant::Billing::Response.new(true, "Transaction Credited with #{amount}", response,
         authorization: response_code)
     end
 
-    def void(_response_code, options)
+    def void(response_code, options)
       payment_source = options[:originator].source
-      payment_id = payment_source.square_payment_id
-      response = cancel_payment(payment_id)
+      response = cancel_payment(response_code)
       payment_source.update!(status: response[:status])
 
       ActiveMerchant::Billing::Response.new(true, 'Transaction voided', response, authorization: response[:id])

--- a/app/models/solidus_square/payment_source.rb
+++ b/app/models/solidus_square/payment_source.rb
@@ -7,7 +7,7 @@ module SolidusSquare
     validates :token, presence: true
 
     def can_void?(payment)
-      result = payment.payment_method.gateway.get_payment(payment.source.square_payment_id)
+      result = payment.payment_method.gateway.get_payment(payment.response_code)
       status = result[:card_details][:status]
       status != "CAPTURED"
     end

--- a/app/presenters/solidus_square/payment_source_presenter.rb
+++ b/app/presenters/solidus_square/payment_source_presenter.rb
@@ -21,13 +21,10 @@ module SolidusSquare
         version: version,
         avs_status: payment_data[:card_details][:avs_status],
         expiration_date: expiration_date,
-        # rubocop:disable Naming/VariableNumber
-        last_digits: card_details[:last_4],
-        # rubocop:enable Naming/VariableNumber
+        last_digits: card_details[:last_4], # rubocop:disable Naming/VariableNumber
         card_brand: card_details[:card_brand],
         card_type: card_details[:card_type],
         status: payment_data[:card_details][:status],
-        square_payment_id: payment_data[:id],
         token: payment_data[:order_id]
       }
     end

--- a/app/services/solidus_square/create_payment_service.rb
+++ b/app/services/solidus_square/create_payment_service.rb
@@ -19,8 +19,8 @@ module SolidusSquare
 
     private
 
-    def square_order_id
-      square_payment_response[:order_id]
+    def square_payment_id
+      square_payment_response[:id]
     end
 
     def square_payment_response
@@ -28,7 +28,7 @@ module SolidusSquare
     end
 
     def create_payment!
-      order.payments.find_or_create_by!(response_code: square_order_id) do |payment|
+      order.payments.find_or_create_by!(response_code: square_payment_id) do |payment|
         payment.amount = payment_amount
         payment.source = ::SolidusSquare::PaymentSource.create!(construct_payment_source)
         payment.payment_method_id = payment_method_id

--- a/app/services/solidus_square/payment_sync_service.rb
+++ b/app/services/solidus_square/payment_sync_service.rb
@@ -38,6 +38,10 @@ module SolidusSquare
       payment_source.update!(construct_payment_source) if new_data?
     end
 
+    def square_payment_id
+      payment_data[:id]
+    end
+
     def square_order_id
       payment_data[:order_id]
     end
@@ -74,7 +78,7 @@ module SolidusSquare
     # Spree Payment information
 
     def payment
-      @payment ||= order.payments.find_by!(response_code: square_order_id)
+      @payment ||= order.payments.find_by!(response_code: square_payment_id)
     end
 
     def payment_source
@@ -82,7 +86,7 @@ module SolidusSquare
     end
 
     def create_square_payment!
-      order.payments.find_or_create_by!(response_code: square_order_id) do |payment|
+      order.payments.find_or_create_by!(response_code: square_payment_id) do |payment|
         payment.amount = order_amount
         payment.source = ::SolidusSquare::PaymentSource.create!(token: square_order_id, version: version)
         payment.payment_method_id = square_payment_method.id

--- a/db/migrate/20211115082652_add_card_info_to_square_payment_sources.rb
+++ b/db/migrate/20211115082652_add_card_info_to_square_payment_sources.rb
@@ -6,6 +6,5 @@ class AddCardInfoToSquarePaymentSources < ActiveRecord::Migration[6.1]
     add_column :solidus_square_payment_sources, :card_brand, :string
     add_column :solidus_square_payment_sources, :card_type, :string
     add_column :solidus_square_payment_sources, :status, :string
-    add_column :solidus_square_payment_sources, :square_payment_id, :string
   end
 end

--- a/lib/solidus_square/testing_support/factories.rb
+++ b/lib/solidus_square/testing_support/factories.rb
@@ -7,6 +7,5 @@ FactoryBot.define do
 
   factory :square_payment_source, class: SolidusSquare::PaymentSource do
     token { "token" }
-    square_payment_id { "123" }
   end
 end

--- a/spec/models/solidus_square/gateway_spec.rb
+++ b/spec/models/solidus_square/gateway_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SolidusSquare::Gateway do
     let(:capture_params) do
       {
         client: gateway.client,
-        payment_id: payment_source.square_payment_id
+        payment_id: payment.response_code
       }
     end
     let(:expected_attributes) do
@@ -113,7 +113,7 @@ RSpec.describe SolidusSquare::Gateway do
       {
         client: gateway.client,
         amount: 123,
-        payment_id: payment_source.square_payment_id
+        payment_id: payment.response_code
       }
     end
 

--- a/spec/models/solidus_square/payment_source_spec.rb
+++ b/spec/models/solidus_square/payment_source_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SolidusSquare::PaymentSource, type: :model do
 
     before do
       allow(payment).to receive(:payment_method).and_return(payment_method)
-      allow(payment).to receive(:source).and_return(OpenStruct.new(square_payment_id: "12345"))
+      allow(payment).to receive(:response_code).and_return("12345")
       allow(payment_method).to receive(:gateway).and_return(gateway)
       allow(gateway).to receive(:get_payment).and_return({ card_details: { status: status } })
     end

--- a/spec/presenters/solidus_square/payment_source_presenter_spec.rb
+++ b/spec/presenters/solidus_square/payment_source_presenter_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe SolidusSquare::PaymentSourcePresenter do
         card_brand: "MASTERCARD",
         card_type: "CREDIT",
         status: "CAPTURED",
-        square_payment_id: 123,
         token: 12
       }
     end

--- a/spec/services/solidus_square/payment_sync_service_spec.rb
+++ b/spec/services/solidus_square/payment_sync_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SolidusSquare::PaymentSyncService do
     end
 
     context "when the version number is higher than the params", vcr: true do
-      let(:payment_source) { order.payments.find_by(response_code: square_order_id).source }
+      let(:payment_source) {  SolidusSquare::PaymentSource.find_by(token: square_order_id) }
 
       before do
         handler.call


### PR DESCRIPTION
fix #52 

# Change Response Code

Before the response code of the payment object was the `square_order_id`, but the `square_order_id` already got stored in the payment_source token. 

I instead stored the `square_payment_id` in the response_code of the payment and modified all the files using the `square_payment_id`.

Removed the `square_payment_id` field of the payment_source as this is no longer needed.