### PR TITLE
Invalidate old payments

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -14,6 +14,17 @@ module SolidusSquare
       )
     end
 
+    def authorize(amount, payment_source, _gateway_options)
+      source_id = payment_source.nonce
+      square_payment = create_payment(amount, source_id)
+      payment_source.update!(payment_source_constructor(square_payment))
+
+      ActiveMerchant::Billing::Response.new(true, 'Transaction approved', square_payment,
+        authorization: square_payment[:id])
+    rescue StandardError => e
+      ActiveMerchant::Billing::Response.new(false, e.message, {})
+    end
+
     def capture(_amount, response_code, options)
       payment_source = options[:originator].source
       response = capture_payment(response_code)

--- a/app/models/solidus_square/payment_source.rb
+++ b/app/models/solidus_square/payment_source.rb
@@ -4,8 +4,6 @@ module SolidusSquare
   class PaymentSource < SolidusSupport.payment_source_parent_class
     self.table_name = 'solidus_square_payment_sources'
 
-    validates :token, presence: true
-
     def can_void?(payment)
       result = payment.payment_method.gateway.get_payment(payment.response_code)
       status = result[:card_details][:status]

--- a/db/migrate/20211115082652_add_card_info_to_square_payment_sources.rb
+++ b/db/migrate/20211115082652_add_card_info_to_square_payment_sources.rb
@@ -6,5 +6,6 @@ class AddCardInfoToSquarePaymentSources < ActiveRecord::Migration[6.1]
     add_column :solidus_square_payment_sources, :card_brand, :string
     add_column :solidus_square_payment_sources, :card_type, :string
     add_column :solidus_square_payment_sources, :status, :string
+    add_column :solidus_square_payment_sources, :nonce, :string
   end
 end

--- a/spec/models/solidus_square/payment_source_spec.rb
+++ b/spec/models/solidus_square/payment_source_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe SolidusSquare::PaymentSource, type: :model do
   let(:payment) { instance_double(Spree::Payment) }
   let(:gateway) { instance_double(SolidusSquare::Gateway) }
 
-  describe 'validations' do
-    it { is_expected.to validate_presence_of(:token) }
-  end
-
   describe "#can_void?" do
     subject(:can_void?) { payment_source.can_void?(payment) }
 


### PR DESCRIPTION
# Invalidate Old Payments

Before when creating a new payment the old payment was not invalidating as we used the pending state on the payment, which doesn't allow the payment to be invalid.

By using the `PaymentCreate` service from Solidus we are able to create a payment in the correct state using the appropriate way.

As Solidus will call the `#authorize` method on the gateway when an order gets completed, I have added the create payment on square method in the `#authorize` method of the gateway.

I have changed the `CreatePaymentService` as we no longer will use this service to create payments on square, but instead, use this to save the nonce on the payment source. 

fix #55 