### PR TITLE
Add purchase method

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -78,11 +78,12 @@ module SolidusSquare
       )
     end
 
-    def create_payment(amount, source_id)
+    def create_payment(amount, source_id, auto_capture)
       ::SolidusSquare::Payments::Create.call(
         client: client,
         amount: amount,
-        source_id: source_id
+        source_id: source_id,
+        auto_capture: auto_capture
       )
     end
 

--- a/app/services/solidus_square/payments/create.rb
+++ b/app/services/solidus_square/payments/create.rb
@@ -3,10 +3,11 @@
 module SolidusSquare
   module Payments
     class Create < ::SolidusSquare::Base
-      def initialize(client:, source_id:, amount:)
+      def initialize(client:, source_id:, amount:, auto_capture:)
         @client = client
         @source_id = source_id
         @amount = amount
+        @auto_capture = auto_capture ? true : false
 
         super
       end
@@ -17,7 +18,7 @@ module SolidusSquare
 
       private
 
-      attr_reader :client, :source_id, :amount
+      attr_reader :client, :source_id, :amount, :auto_capture
 
       def create_payment
         handle_square_result(client.payments.create_payment(body: payment_payload)) do |result|
@@ -33,7 +34,7 @@ module SolidusSquare
             amount: amount,
             currency: "USD"
           },
-          autocomplete: false
+          autocomplete: auto_capture
         }
       end
     end

--- a/spec/services/solidus_square/payments/create_spec.rb
+++ b/spec/services/solidus_square/payments/create_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe SolidusSquare::Payments::Create, type: :request do
   subject(:create_payment) {
-    described_class.new(client: client, source_id: "nonce", amount: 19.99)
+    described_class.new(client: client, source_id: "nonce", amount: 19.99, auto_capture: false)
   }
 
   let(:client) do


### PR DESCRIPTION
fix #62 

# Add Purchase Method

I made the Create service more generic in order to create payments on Square that are either way captured or authorized.

As that method is able to create captured payments as well I simply called the authorize method inside the purchase method.