### PR TITLE
Use payment_method instead of SolidusSquare.config

### DIFF
--- a/app/views/spree/admin/payments/source_forms/_square.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_square.html.erb
@@ -1,1 +1,1 @@
-<%= render 'spree/shared/square', frontend: false %>
+<%= render 'spree/shared/square', frontend: false, payment_method: payment_method %>

--- a/app/views/spree/checkout/payment/_square.html.erb
+++ b/app/views/spree/checkout/payment/_square.html.erb
@@ -1,1 +1,1 @@
-<%= render 'spree/shared/square', frontend: true %>
+<%= render 'spree/shared/square', frontend: true, payment_method: payment_method %>

--- a/app/views/spree/shared/_square.html.erb
+++ b/app/views/spree/shared/_square.html.erb
@@ -6,10 +6,11 @@
 </form>
 
 <div id="payment-status-container"></div>
+
 <div
   id="square-checkout-payload"
-  data-location-id="<%= SolidusSquare.config.square_location_id %>"
-  data-app-id="<%= SolidusSquare.config.square_app_id %>"
+  data-location-id="<%= payment_method.preferred_location_id %>"
+  data-app-id="<%= payment_method.preferred_app_id %>"
   data-order-number="<%= @order.number %>"
   data-order-token="<%= @order.guest_token %>"
   data-order-total="<%= @order.total.to_f %>"


### PR DESCRIPTION
As Solidus is providing us the payment_method we no longer have to extract the
`app_id` and `location_id` from the `SolidusSquare.config`.