### PR TITLE
Add translation key for the payment method

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,6 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: Hello world
+  activerecord:
+    models:
+      solidus_square/payment_method: Square


### PR DESCRIPTION
As solidus will display the class name as payment method type in the
admin panel when creating a new payment method, it will just display
`Payment method` as the class name is PaymentMethod.

In order to make this more square specific, I have added a translation
key for that model.