### PR TITLE
Save card token

### DIFF
--- a/app/decorators/models/spree/user/add_square_customer.rb
+++ b/app/decorators/models/spree/user/add_square_customer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spree::User::AddSquareCustomer # rubocop:disable Style/ClassAndModuleChildren
+  def self.prepended(base)
+    base.has_one :square_customer, class_name: 'SolidusSquare::Customer'
+  end
+
+  Spree::User.prepend(self)
+end

--- a/app/models/solidus_square.rb
+++ b/app/models/solidus_square.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SolidusSquare
+  def self.table_name_prefix
+    'solidus_square_'
+  end
+end

--- a/app/models/solidus_square/customer.rb
+++ b/app/models/solidus_square/customer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_dependency 'solidus_square'
+
+module SolidusSquare
+  class Customer < ApplicationRecord
+    belongs_to :user, class_name: 'Spree::User'
+  end
+end

--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -141,7 +141,7 @@ module SolidusSquare
       auto_capture = payment.payment_method.auto_capture
       square_payment = create_payment(amount, source_id, auto_capture, customer_id)
       payment.response_code = square_payment[:id]
-      if payment_source.token.nil?
+      if payment_source.token.nil? && order.user.present?
         card = create_card(square_payment[:id], order.bill_address, square_customer_ref(order))
         payment_source.update!(token: card[:id])
       end

--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -108,6 +108,21 @@ module SolidusSquare
       SolidusSquare::PaymentSourcePresenter.square_payload(data)
     end
 
+    def create_profile(payment)
+      user = payment.order.user
+      return if user.nil?
+      return if user&.square_customer&.square_customer_ref
+
+      square_customer = SolidusSquare::Customers::Create.call(
+        client: client, spree_user: payment.order.user, spree_address: payment.order.bill_address
+      )
+
+      payment.source.create_customer(
+        square_customer_ref: square_customer[:id],
+        user: payment.order.user
+      )
+    end
+
     private
 
     def create_payment_on_square(amount, payment_source, gateway_options)

--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -145,7 +145,7 @@ module SolidusSquare
         source_id = payment_source.nonce
         square_payment = create_payment(amount, source_id, auto_capture)
 
-        if order.user.present?
+        if payment.payment_method.payment_profiles_supported? && order.user.present?
           card = create_card(square_payment[:id], order.bill_address, square_customer_ref(order))
           payment_source.update!(token: card[:id])
         end

--- a/app/models/solidus_square/payment_method.rb
+++ b/app/models/solidus_square/payment_method.rb
@@ -10,12 +10,18 @@ module SolidusSquare
 
     NOT_VOIDABLE_STATUSES = %w[CAPTURED VOIDED].freeze
 
+    delegate :create_profile, to: :gateway
+
     def gateway_class
       ::SolidusSquare::Gateway
     end
 
     def payment_source_class
       ::SolidusSquare::PaymentSource
+    end
+
+    def payment_profiles_supported?
+      true
     end
 
     def partial_name

--- a/app/models/solidus_square/payment_source.rb
+++ b/app/models/solidus_square/payment_source.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
+require_dependency 'solidus_square'
+
 module SolidusSquare
   class PaymentSource < SolidusSupport.payment_source_parent_class
-    self.table_name = 'solidus_square_payment_sources'
 
     def can_void?(payment)
       return false unless payment.response_code

--- a/app/models/solidus_square/payment_source.rb
+++ b/app/models/solidus_square/payment_source.rb
@@ -15,6 +15,10 @@ module SolidusSquare
       !SolidusSquare::PaymentMethod::NOT_VOIDABLE_STATUSES.include?(status)
     end
 
+    def reusable?
+      true
+    end
+
     def captured?
       status == "CAPTURED"
     end

--- a/app/models/solidus_square/payment_source.rb
+++ b/app/models/solidus_square/payment_source.rb
@@ -4,6 +4,7 @@ require_dependency 'solidus_square'
 
 module SolidusSquare
   class PaymentSource < SolidusSupport.payment_source_parent_class
+    belongs_to :customer, class_name: 'SolidusSquare::Customer', optional: true
 
     def can_void?(payment)
       return false unless payment.response_code

--- a/app/presenters/solidus_square/payment_source_presenter.rb
+++ b/app/presenters/solidus_square/payment_source_presenter.rb
@@ -24,8 +24,7 @@ module SolidusSquare
         last_digits: card_details[:last_4], # rubocop:disable Naming/VariableNumber
         card_brand: card_details[:card_brand],
         card_type: card_details[:card_type],
-        status: payment_data[:card_details][:status],
-        token: payment_data[:order_id]
+        status: payment_data[:card_details][:status]
       }
     end
 

--- a/app/services/solidus_square/cards/create.rb
+++ b/app/services/solidus_square/cards/create.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SolidusSquare
+  module Cards
+    class Create < ::SolidusSquare::Base
+      attr_reader :client, :source_id, :bill_address, :customer_id
+
+      def initialize(client:, source_id:, bill_address:, customer_id:)
+        @client = client
+        @bill_address = bill_address
+        @customer_id = customer_id
+        @source_id = source_id
+
+        super
+      end
+
+      def call
+        create_card
+      end
+
+      private
+
+      def create_card
+        handle_square_result(client.cards.create_card(body: construct_card)) do |result|
+          result.data&.card
+        end
+      end
+
+      def construct_card
+        {
+          idempotency_key: idempotency_key,
+          source_id: source_id,
+          card: {
+            cardholder_name: bill_address.name,
+            customer_id: customer_id,
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/services/solidus_square/payments/create.rb
+++ b/app/services/solidus_square/payments/create.rb
@@ -3,11 +3,12 @@
 module SolidusSquare
   module Payments
     class Create < ::SolidusSquare::Base
-      def initialize(client:, source_id:, amount:, auto_capture:)
+      def initialize(client:, source_id:, amount:, auto_capture:, customer_id: nil)
         @client = client
         @source_id = source_id
         @amount = amount
         @auto_capture = auto_capture ? true : false
+        @customer_id = customer_id
 
         super
       end
@@ -18,7 +19,7 @@ module SolidusSquare
 
       private
 
-      attr_reader :client, :source_id, :amount, :auto_capture
+      attr_reader :client, :source_id, :amount, :auto_capture, :customer_id
 
       def create_payment
         handle_square_result(client.payments.create_payment(body: payment_payload)) do |result|
@@ -34,8 +35,14 @@ module SolidusSquare
             amount: amount,
             currency: "USD"
           },
-          autocomplete: auto_capture
-        }
+          autocomplete: auto_capture,
+        }.merge(customer_params)
+      end
+
+      def customer_params
+        return {} if customer_id.nil?
+
+        { customer_id: customer_id }
       end
     end
   end

--- a/app/views/spree/checkout/existing_payment/_square.html.erb
+++ b/app/views/spree/checkout/existing_payment/_square.html.erb
@@ -1,0 +1,8 @@
+<tr id="<%= dom_id(wallet_payment_source, 'spree')%>" class="<%= cycle('even', 'odd') %>">
+  <td><%= wallet_payment_source.payment_source.card_brand %></td>
+  <td><%= wallet_payment_source.payment_source.last_digits %></td>
+  <td><%= wallet_payment_source.payment_source.expiration_date %></td>
+  <td>
+    <%= radio_button_tag "order[wallet_payment_source_id]", wallet_payment_source.id, default, class: "existing-cc-radio" %>
+  </td>
+</tr>

--- a/db/migrate/20220118153633_create_solidus_square_customers.rb
+++ b/db/migrate/20220118153633_create_solidus_square_customers.rb
@@ -1,0 +1,10 @@
+class CreateSolidusSquareCustomers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :solidus_square_customers do |t|
+      t.string :square_customer_ref
+      t.references :user
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220118161806_add_customer_to_solidus_square_payment_source.rb
+++ b/db/migrate/20220118161806_add_customer_to_solidus_square_payment_source.rb
@@ -1,0 +1,5 @@
+class AddCustomerToSolidusSquarePaymentSource < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :solidus_square_payment_sources, :customer
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_Cards_Create/Creates_the_Card_on_square.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_Cards_Create/Creates_the_Card_on_square.yml
@@ -1,0 +1,166 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"990400584936853","amount_money":{"amount":123,"currency":"USD"},"source_id":"cnon:card-nonce-ok","external_details":{"type":"CHECK","source":"Food
+        Delivery Service"},"autocomplete":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jan 2022 19:14:37 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '760'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVUXXOiMBR931/h8LhTd8QvtG+IWFk/QIi2urOTCRA0FQFDULHT/74JSutuH7p9Us65l9xz7gkvUoLyHY6YdF95kYjPf6RNR6VdNxhMzIfFptvWBwP2c+8c98F4uVpKd5JHMWLYh0g0SfVavV6tyVW5C+Tuvdy8byg/OrXaihdmif9JYbemiEK0i7OIwV0c4bwY5ALwv3K9wQ/MKMWRJyhp7vSl1zspZYhlqQBUy7LNhd7nr/FxiHLoZxQxEkeCtIDc7gw5lcYZ9TBkeYIFrqm2aPAQ9aGPGSJhWpx789o5GJq2sdLLuoIvGlyKosKoheGonA1RymBTAK1Oq8MBfEqEFrYRAi6POUaUP3EPmndSQKI1pgklhUQp3Vfl6k8TzMK6slFaIAVGFiujs19FQxuE/iRIj0Z7dTz6S9/U10p1q4JHNaCqFXRO7snUGgMZWrNSz5tGW+8bgKMJxQki78TUBNCydUs1hDaXFE41W4260hLW8jDQHO4w28SFypG+vJhwOMB3f7TFAqqaplugINEhvSHVhXNLCgKLkHGvU4+SpFyPM6t87+sDdT4GFaA7oMKbzPkUlFKu2YSM7HBIInzJRsYno+T8ebBeuZow9oo0wEu2xw9Tu9nQls7gabngx8TUx/TKPfthMuwpi3l7vMFe4hhgS7RVNhnNgiL3lKRbiA8ozMp8vfzHXbhGvGgO8QGHlxXYE3Us3GYxQ+FXko+ShMYHfuQXejyUIJeEhBEs9vNLEsmA6kR4DecWH+8W6JuP0xIChvWx7gYsan9zedjDfK8wynYupuVX5O1OIq9cuaZONX1cElwGn5yEt+bV2x8+JFxzSK57/Ou67jNEMeSG+JlXbEDXzMlEtzUdqpbxT+dlyym/vG58qqb7GvHdquG1lfM52Do50fLjqLNPzifzKEw7YJqKNhZvcTH6+pypx02LeTiddVN7uX46kgdydv2kd+jJwanVQlZv+5zMH/N2zMP37Q88l8g1XQUAAA==
+  recorded_at: Wed, 19 Jan 2022 19:14:37 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers
+    body:
+      encoding: UTF-8
+      string: '{"given_name":"John","family_name":"Doe","email_address":"john.doe@gmail.com"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jan 2022 19:14:39 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '235'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2PXUvDMBSG7/0VkmtXkuqQ9sqtFb8QpJat7iZkyemMNMlImoGM/ndPNvHSqwPP+5xzeI9ExjA6A56Ul0eiFQ7S0eJ9tayq29euW9GqeZnfb9jDel1X5IpID2IExcWY1Jzm+YyyGStaVpTsprwusjnNNyjGvfpfTNJOH8ByKwwk6dl9WoS9MHr4/qO1A4RghB64UMpDCAl/oZwpB3e7lGTSGbT2HnrwYCWEU6HzVrQhboP0egupYC+GANNvFe0sDy56efrVPj41NX9bNO0HXjuAD5hjQKfp4gdtG0LvLAEAAA==
+  recorded_at: Wed, 19 Jan 2022 19:14:39 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/cards
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"af1888de-948b-4967-8e59-a7ec2f709d83","source_id":"h8Ar9bfFMOGVh96EFFtJqSwqfLYZY","card":{"cardholder_name":"John
+        Von Doe","customer_id":"X09SVBCC7MXXV0CRK5EZ1GWWDC"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Speleo-Traceid:
+      - JZaBCVKWbHTbP
+      X-Xss-Protection:
+      - 1; mode=block
+      Date:
+      - Wed, 19 Jan 2022 19:14:45 GMT
+      Content-Length:
+      - '326'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAA/ySQ3a6iMBRGX+VkX0NC+TlI7zgcddQY/CHocNMUWoSZ2jotRGaM7z6pXu5k5cta+wEN1QzwA3oGGJpGtXjDxqqe8mMTdIX6tVuEyy9wXhypNZWWK1fHFBwQ1AwkBAzRLJqBA3y6kauSQwcYva+/nGrAvueH74VOCcY1kfTKAcNadfKjVPLjW3FwoO6F6OWFUMY0N8Za3ZQZqCCNYpZPQuQF8HSg7eWF65vu5QAYzB8Xueu82As/7uKoMMVqVPHmH3Ppj0Mh2LY199Vndb+znyyfX2L3d1qc0lanu3Y21VOeBQtEdnsbOZpBXbkmr2+cveRYfmVZvD2fSy87bKJ5hZan03dmWyWtBWeABz1y6y4BQxgFfhzZIc3pwBmh1s/3fN/1kIuSAiUYhTj8rOD5/B8AAP//C4ZsMHwBAAA=
+  recorded_at: Wed, 19 Jan 2022 19:14:45 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_the_order_is_not_in_payment_state/doesn_t_complete_the_order.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_the_order_is_not_in_payment_state/doesn_t_complete_the_order.yml
@@ -100,4 +100,110 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAMVUXW/aMBR936+o/JxNmJJ28NYNirqNDmi6qEyTZZwLeEtsal9DUtT/PjvppD2gaUGaJkWKP8659/qcq3sg2mRgyODsQGTmf+T9Yy6vbiarcqGm40pX8+puvHzal4XoXZOI5FpwlFqxBv3pw9WsGyeT+ex8NAzXUgGTCIX1t18PxDWw8nr4Lvk4Gd2mizRJq3I9XX1XHv7ouEKJVcBQv1e8gLD+HIo6Q40896dLboFtjRTACq2gqqvlhXYK/ZLSTqcTEeGMASXqUPd3Q/IckbXR1jLLc7DtiHVihrw8RvsTJZNWBFhbXqvqdtzIxoOGfIIywSGG1bYW+yYZTcjzt4gUgDzjyOsoG20RMiY2IH5o58MRNA4CWRjg4YqHHKTb6dLX1H9xQnuD8/6Axm/it/HC++a22d8BLXpc7ft0dOv3OzDWvy88ISIGVhDqh5eWm/dp/5JeXlz0yH9wCuX2n5rbUCyYXTBVbLhZH/X2OFsBsgZia/gpBbTR8gQV2+h3mgyBqJ0RUEN/jRSrc5k5Pw78zDHAECyy31op9LWzqAswL322SOmGp/tyNv7Se0jpfjm+dw/dPvoEr34CDoZIjDcFAAA=
   recorded_at: Thu, 18 Nov 2021 10:22:07 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email5@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:20 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '500'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RUY+iMBSF3/dXGJ5H04K4g8kkC1p0nRERAaObDalQlSxtmRZcjfG/b6u7M2/70LQ99+vJ6b1XI29lwykR0hh2flyNslC78WoD09puZtP+2psixxnE6wnwrY0fGU9GLghuSJHhRqMmMM0ugF0TxLA/tJ2hZfae+/ZWgW1d/B/U0KE8EZYxTImGZvzIlLjHtKwuH+qYEyUSissqw0UhiNRpH4L9jZwxrSvSyzlV1Gf9+u+cVSUjGdRPwkXH4+cOtKyvn+yjbup6wEVz/E1ko6oVz3FVNhetT4lgBdfRai4bXGU5L+7RIADA0U3hLWvEnU1Wxk1xR65MWUt3RGjVtu2uXgA6mhdkTwRhOckeHYfa+kN8xH98uGWy3clclDuiyT2uJLn9nULJWSZ5K/J7lnj6PRpnoRvFG+UmyYES1ij/+2iN+dsKQfd5DEOQBr0IuaOp670h4+eTcVLjV1YKAzd1zVsh+T306ACD2A/8eYL60dhfzv3tYnKs8cQ9eOi4xIimzWZdySDxKjLxm3xyrt5ocNqtZu7IRasQBV6U+l5CHRHTeoQRuKSxF6YwBWtas3li1/OxhyOwfY/94nWH4ABbEU7R7H39K2JBYg+WtF5gGolV4s/CFUfKd+kuX16M25c/uwsEI74CAAA=
+  recorded_at: Thu, 20 Jan 2022 15:12:20 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email5@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:21 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '499'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RXY+iMBiF7/dXGK5H06LsDiaTLGjBdQdUPvzabEiFqmQKJW1xNMb/vq3uztztBYGe8/Tk8L5XI2+FZBXhwhh2fl2NslBv46cFzP52M50MVu4E2fbXZOUDr7/xIuPJyDnBkhQZlho1gWl2AeyaIIGDoWUP+2bveWBtFdg2xf9BDR3KE6mzGldEQ1N2rJW4x1VJLx/qmBElkgqXNMNFwYnQbR+C9Z2ccdVQ0stZpahP//rvO6NlTTKor8xnHZedO7Df//bJPnxT+yHj8vhOhFQuZTmmpbxofUJ4XTBdrWFCYprlrLhXgwAAWw+FtbXkdzaNjZvijkyF1m21I1yrlmV19QOgrXlO9oSTOifZY+JQR3+Ij/qPH25r0e5Ezssd0eQeU0Fuf7dQsjoTrOX5vUsy+RGNs7kTJRuVJsihIrVU+ffVGsFrjKDzPIZzsAx7EXJGE8d9RcbvJ+Ok1q+iFAZu6pi3XLB76dEBhokXekGKBtHYWwTeduYfG+w7BxcdFxhVS7lZURGmLiW+J3P/TF+r8LSLp87IQfEchW609Ny0svlqGcU4tRH25SxCECSrJgo8mgRjd0botEm8wseQrpN1NIvAVijfxwiiaN1sg7e3S5x603nMkMpdOIuXF+P25Q+sllYRvgIAAA==
+  recorded_at: Thu, 20 Jan 2022 15:12:21 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_the_version_number_is_higher_than_the_params/doesn_t_change_the_status_of_the_payment_source.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_the_version_number_is_higher_than_the_params/doesn_t_change_the_status_of_the_payment_source.yml
@@ -100,4 +100,110 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAMVUXW/aMBR936+o/JxNmJJ28NYNirqNDmi6qEyTZZwLeEtsal9DUtT/PjvppD2gaUGaJkWKP8659/qcq3sg2mRgyODsQGTmf+T9Yy6vbiarcqGm40pX8+puvHzal4XoXZOI5FpwlFqxBv3pw9WsGyeT+ex8NAzXUgGTCIX1t18PxDWw8nr4Lvk4Gd2mizRJq3I9XX1XHv7ouEKJVcBQv1e8gLD+HIo6Q40896dLboFtjRTACq2gqqvlhXYK/ZLSTqcTEeGMASXqUPd3Q/IckbXR1jLLc7DtiHVihrw8RvsTJZNWBFhbXqvqdtzIxoOGfIIywSGG1bYW+yYZTcjzt4gUgDzjyOsoG20RMiY2IH5o58MRNA4CWRjg4YqHHKTb6dLX1H9xQnuD8/6Axm/it/HC++a22d8BLXpc7ft0dOv3OzDWvy88ISIGVhDqh5eWm/dp/5JeXlz0yH9wCuX2n5rbUCyYXTBVbLhZH/X2OFsBsgZia/gpBbTR8gQV2+h3mgyBqJ0RUEN/jRSrc5k5Pw78zDHAECyy31op9LWzqAswL322SOmGp/tyNv7Se0jpfjm+dw/dPvoEr34CDoZIjDcFAAA=
   recorded_at: Thu, 18 Nov 2021 10:33:51 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email6@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:22 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '501'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RS4/aMBSF9/0VKOsB2YF0AGmkJpBAmSFAXjyqKjKJIRF2HNkOwwjx32tDO7PrwrJ97uej43uvRtYIySjmwhi2fl2NMle7kYCt7wOrt1oHaw9uurvXfjKwN/YrMJ6MjGMkcZ4iqVETmGYbwLYJItgbWoNh97kDzf5OgU2d/x/U0LE84yqtEMUamrGiUuIB0ZJ8fKpjhpWIKSpJivKcY6HTPoTvP/AF0ZrgTsaoor7q13/nlJQVTqF+sly0HHZpwW73+Yt91E1d9xmXxTsWUlUJyxAp5YfWp5hXOdPRaiYkImnG8ns0CACEuimsqSS/s3Fo3BRXMGVaNXSPuVYty2rrBeBgoHiOD5jjKsPpo+Pao/4UH/EfH24q0exFxss91uQBEYFvf6dQsioVrOHZPUs0/RmM06UdRFvlJvCR4koq//tojflb6EK7P4ZLkPidwLVHU9t5c43fT8ZZjV9ZKQzc1DVruGD30KMj9CPP9+ax2wvG3mru7RaTokYT++i4xQq5NJHbNRH+ySF44slsciFv1D/vw5k9st1w6fpOkHhOTAc8OuWzHMBpvCl8RHMQxcEaxTCajx2EqOxGXsB9j2yCTbBIJoVYkwAhYLkBrXfotGNh7M2WIXOV78pevbwYt29/AKDTC5a+AgAA
+  recorded_at: Thu, 20 Jan 2022 15:12:22 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email6@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:22 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '502'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RX4+iMBTF3/dTGJ5HQ1F2RpNJFhR0/YOIgMpmQypclUxL3VJcHeN331Z3Z972oWl77q8np/detayuBKPAK63X+HHVilzuWqxvPE83O4tVsHLRup1MXuKutbYmuvakZRywgDzFQqGGbhhNHTUNPUSdntnttZ9byHhJJFgf8/+DCtoXJyjTElNQ0JgdSinuMC3I5UMdMJAiUFyQFOc5h0qlfQhfv8EZ0yOBVsaopD7r13/nlBQlpEg98ecNm50bqN1+/mQfdUPVPcbF4TdUQlYJyzApxEXpI+BlzlS0I6sEJmnG8ns0pOsIqaawuhT8zkZL7Sa5A5OmZU23wJVqmmZTLR11u5LnsAMOZQbpo+PK4/ghPuI/PlyXVb2tMl5sQZE7TCq4/Z1Cwcq0YjXP7lnC0fdgkPpWEG6kWwV7CqWQ/vfRarPp0kHWywD5euy1Asfqjyx76mg/n7STHL+0kph+k9es5hW7h+7vkRe6njuLnE4wcBczN5kPD0c8tPa2c1hgh8ZisyKV92YTGLoiG57JlHqn7XJs9S1n6TueHcSuHdEuD0kQexFyNu82jlGsh/RYQmSGs4GdABVm6OYTHHUu8TrwAycRK4qSGSK/8Hs8x29uexm5Y3/JHOm7sBavr9rtyx944grAvgIAAA==
+  recorded_at: Thu, 20 Jan 2022 15:12:22 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/creates_a_Spree_Payment.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/creates_a_Spree_Payment.yml
@@ -100,4 +100,110 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAMVUXW/aMBR936+o/JxNmJJ28NYNirqNDmi6qEyTZZwLeEtsal9DUtT/PjvppD2gaUGaJkWKP8659/qcq3sg2mRgyODsQGTmf+T9Yy6vbiarcqGm40pX8+puvHzal4XoXZOI5FpwlFqxBv3pw9WsGyeT+ex8NAzXUgGTCIX1t18PxDWw8nr4Lvk4Gd2mizRJq3I9XX1XHv7ouEKJVcBQv1e8gLD+HIo6Q40896dLboFtjRTACq2gqqvlhXYK/ZLSTqcTEeGMASXqUPd3Q/IckbXR1jLLc7DtiHVihrw8RvsTJZNWBFhbXqvqdtzIxoOGfIIywSGG1bYW+yYZTcjzt4gUgDzjyOsoG20RMiY2IH5o58MRNA4CWRjg4YqHHKTb6dLX1H9xQnuD8/6Axm/it/HC++a22d8BLXpc7ft0dOv3OzDWvy88ISIGVhDqh5eWm/dp/5JeXlz0yH9wCuX2n5rbUCyYXTBVbLhZH/X2OFsBsgZia/gpBbTR8gQV2+h3mgyBqJ0RUEN/jRSrc5k5Pw78zDHAECyy31op9LWzqAswL322SOmGp/tyNv7Se0jpfjm+dw/dPvoEr34CDoZIjDcFAAA=
   recorded_at: Thu, 18 Nov 2021 14:27:51 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email1@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:13 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '501'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RX2/aMBTF3/cpUJ4LsoFQQKq0BJIwVtKQf4xMU2SSC0Rz4tROGB3iu8+GrX3bg2X73J+Pju+9aFkrGlYCF9q08/2iFbnctY2+HXnfsDdAgfN1lCxGG7Qwt4kz2WgPWsaBNJCnpFFoH/X7XYS7fRTi4VQfT9Gw9zgeJxJs6/z/oIIOxQmqtCIlKGjJjpUU96Qs6Nu7OmcgRShJQVOS5xyESnsX8Gc4k7Km0MtYKamP+uXfOaVFBSlWT7yXjsnOHTwYPH6w93pf1V3Gm+MvEI2sUpYRWjRvSl8Ar3KmotVMNISmGctv0TBCCKumsLZq+I2NAu0quSOTplVb7oArVdf1rloITyaS57AHDlUG6b3jyqN+F+/x7x9uK9HuRMaLHShyT6iA698pFKxKBWt5dssSLr7489Qz/HAr3QQcSqga6X8brbZ6DixsjOfYQ7Hb8y1jtjDMZ0v78aCd5PillcTQVV6zlgt2Cz07YDe0XXsVWUN/bq9XdvLiHGviGAfTOq6JVcbNdkPFKjIpOHaTOWf6XLqnXbA0ZoYVeJZr+rFtRuWEb8IlIT8nUeJQdxfFKES5Q2gdruZmEuNEhHa+dCP8mgx8N3bE7xD5LkS65BvXt+gwiOylFzBL+q6N9dOTdv30B0UgvXK+AgAA
+  recorded_at: Thu, 20 Jan 2022 15:12:13 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email1@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:14 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '502'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RS4/aMBSF9/0VKOsB2UAYQBqpCXlQSkLIgwxUVWQSA9E4duQ4DCPEf68N7cyuC8v2uZ+Pju+9annbCFZh3mjTzq+rVhZy11J9OwpeYTAAkftztJuPUjA3tzt3kmpPWs4xErjIkFBoH/T7XQC7fRDD4VQfT8Gw9zwe7yTY1sX/QQUdyzOmGUUVVtCCnagUD6gqycenajEsRVyhkmSoKDhuVNqHAL/jC6pqgns5qyT1Vb/+O2ekpDiD6kmw6pjs0oGDwfMX+6j3Vd1nXJzecSNklbAckVJ8KH2OOS2YilazRiCS5ay4R4MAAKiawloq+J1NIu0muROTprSt9pgrVdf1rloATiaS5/iAOaY5zh4dVx71p/iI//hwS5t23+S83GNFHhBp8O3vFEpGs4a1PL9niec/QisLjDDeSrcGHytMhfS/j1bzlpENjbEFA7Dxe6FtzOaGubS130/aWY5fWkkM3OQ1b3nD7qFnR+jHju94iT0MLWftObuVe6qRaxxN+7RGdrUR25Q0XmIS7Doidy9kWfnnfbQwZoYdBbZvhhvHTKoJj5OQ+raepLGzwmQDYlovPHtieZa5Q296HTuFUwCYpK/hynsD7zEoUgSJSGNztZFdjhJnEUTMlr5rY/3yot2+/QF6y5DSvgIAAA==
+  recorded_at: Thu, 20 Jan 2022 15:12:14 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/when_payment_source_is_captured/1_1_1_2_1.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/when_payment_source_is_captured/1_1_1_2_1.yml
@@ -100,4 +100,110 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAMVUXW/aMBR936+o/JxNmJJ28NYNirqNDmi6qEyTZZwLeEtsal9DUtT/PjvppD2gaUGaJkWKP8659/qcq3sg2mRgyODsQGTmf+T9Yy6vbiarcqGm40pX8+puvHzal4XoXZOI5FpwlFqxBv3pw9WsGyeT+ex8NAzXUgGTCIX1t18PxDWw8nr4Lvk4Gd2mizRJq3I9XX1XHv7ouEKJVcBQv1e8gLD+HIo6Q40896dLboFtjRTACq2gqqvlhXYK/ZLSTqcTEeGMASXqUPd3Q/IckbXR1jLLc7DtiHVihrw8RvsTJZNWBFhbXqvqdtzIxoOGfIIywSGG1bYW+yYZTcjzt4gUgDzjyOsoG20RMiY2IH5o58MRNA4CWRjg4YqHHKTb6dLX1H9xQnuD8/6Axm/it/HC++a22d8BLXpc7ft0dOv3OzDWvy88ISIGVhDqh5eWm/dp/5JeXlz0yH9wCuX2n5rbUCyYXTBVbLhZH/X2OFsBsgZia/gpBbTR8gQV2+h3mgyBqJ0RUEN/jRSrc5k5Pw78zDHAECyy31op9LWzqAswL322SOmGp/tyNv7Se0jpfjm+dw/dPvoEr34CDoZIjDcFAAA=
   recorded_at: Thu, 18 Nov 2021 14:27:55 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email3@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:17 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '501'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RX4+aQBTF3/spDM+rYUS6i8kmBQWsu7DIH1GbhoxwVVKGITPgao3fvTPa7r71gcCc85uTw70XJe94Swkwrox7Py5KWYi3snaM2H5B3ouXar7mpstgZVrr0UgLlQclZ4BbKDLcSnSoDod9FfWHaoxGY90YDx8H6pOxEWDXFP8HJbQvj1BnNSYgoTk91ELcYVJW5w91SkGIQHBZZbgoGHDZ9i5o3+CESVPBIKdEUJ/+5d93VpU1ZEheCd56Fj31kKY9frJ3fyh9n7L28A68FW5Fc1yV7VnqM2B1QWW1hvIWV1lOi1s1pKqqLodCu7plNzaJlKvgDlSE1h3ZApOqrut9+ajIMATPYAcM6hyy+8SRjP4Q7/XvP9zVvNvynJVbkOQOVxyuf7dQ0jrjtGP5rUs8+x5Os8AM47VI47AnULci/7ZaxXuNbGQ+TVGgLv1BaJuTmWm92srPB+Uo1i+iBKZexTHvGKe30pM98mPHd7zEHoVTZ+E5mzf30GDX3Fv2YYFtsmzXacU91arAddrcPVWvxD9uo7k5Me0osH0rXDpWQgyWkmbjJ2iVxlYQur6arhrLcyrdm1obTPgpdoq57zSrZBVu4FdyjpdhDTb6Gseh8PPfUeLMg4jaIndhLp6fleuXPz9tXhe+AgAA
+  recorded_at: Thu, 20 Jan 2022 15:12:17 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email3@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:18 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '502'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RzW7iMBSF9/MUKOuC7ATUglRpEkhgKAkhf5SMRpFJDES149RxKAjx7rVhpt3NwrJ97uej43svWt42glHMG23U+X3RykLu2sYZRvYLdF/cteEZ03Xiv5rWpt83Au1ByzlGAhcZEgrVga53AezqIIL90WA40h974GmYSrCti/+DCtqXR1xlFaJYQXN2qKS4Q7Qk5y91wrAUMUUlyVBRcNyotHfB+IlPiNYE93JGJfVdv/w7Z6SscAbVE3/ZsdipAw3j8Zu913VV9xgXhw/cCFklLEekFGelzzCvCqai1awRiGQ5K27RIABgoJrC2krwGxuH2lVyByZNq5ZuMVfqYDDoqgXgcCh5jneY4yrH2b3jUFl/iff49w+3VdNum5yXW6zIHSINvv6dQsmqrGEtz29ZotmvYJL5ZhBtpFuD9xRXQvrfRqu5i9CG5tME+iDxeoFtjmemtbC1Pw/aUY5fWkkMXOU1b3nDbqHHe+hFjue4sd0PJs7KddLl9FCjqbm37MMK2TQRmzVpXGARPHVEPj2RBfWO23Bujk079G3PChLHiumQR2sY4KR+X9PTMnEcsKYQITCo3YmVum/xR+QUU+TUInoNvMRO36OqTl1I4tQgaBu/ncPYmfshs6Xvylw9P2vXH5/yNMXjvgIAAA==
+  recorded_at: Thu, 20 Jan 2022 15:12:18 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/when_payment_source_is_captured/1_1_1_2_2.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/when_payment_source_is_captured/1_1_1_2_2.yml
@@ -100,4 +100,110 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAMVUXW/aMBR936+o/JxNmJJ28NYNirqNDmi6qEyTZZwLeEtsal9DUtT/PjvppD2gaUGaJkWKP8659/qcq3sg2mRgyODsQGTmf+T9Yy6vbiarcqGm40pX8+puvHzal4XoXZOI5FpwlFqxBv3pw9WsGyeT+ex8NAzXUgGTCIX1t18PxDWw8nr4Lvk4Gd2mizRJq3I9XX1XHv7ouEKJVcBQv1e8gLD+HIo6Q40896dLboFtjRTACq2gqqvlhXYK/ZLSTqcTEeGMASXqUPd3Q/IckbXR1jLLc7DtiHVihrw8RvsTJZNWBFhbXqvqdtzIxoOGfIIywSGG1bYW+yYZTcjzt4gUgDzjyOsoG20RMiY2IH5o58MRNA4CWRjg4YqHHKTb6dLX1H9xQnuD8/6Axm/it/HC++a22d8BLXpc7ft0dOv3OzDWvy88ISIGVhDqh5eWm/dp/5JeXlz0yH9wCuX2n5rbUCyYXTBVbLhZH/X2OFsBsgZia/gpBbTR8gQV2+h3mgyBqJ0RUEN/jRSrc5k5Pw78zDHAECyy31op9LWzqAswL322SOmGp/tyNv7Se0jpfjm+dw/dPvoEr34CDoZIjDcFAAA=
   recorded_at: Thu, 18 Nov 2021 10:18:11 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email2@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:15 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '500'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RX4+iMBTF3/dTGJ5HQ1HW0WSSBfnjGkUEZEY3G1LhqsTSum1xnRi/+xbcnXnbh6btub+envbetLwWklXAhTbu/LhpZaFmbZZsLcOZbMIoTZ1hkkaj5zDY+P3nhfak5RywhCLDskEN3TC6OuoaeoIGY3M0NozecIC2CqzPxf/BBjqUF6AZxRW0F7MjVeIeVyV5/1AdBkqECpckw0XBQTRpH4LxDa64OhPo5axS1Gf99m+dkZJChpoj4bJjs2sH9fvDT/ZRN5p6wLg8/gYhVZWwHJNSvjf6FDgtWBPtzITEJMtZ0UZDuq73m09hNZW8ZdexdlfckSlTWlc74I1qmma3GToajRTPYQ8caA7Z48dRY/0hPuI/HlxTUe9EzssdNOQeEwH3v10oGc0Eq3neZkmm3yMnC60o2Sg3AYcKqFT+bWu1xTx2kfXsoFBPg17kWpOpZc9d7eeTdlHtV1YK0+9qm9dcsDb05ICCxAu8xdodRI63WnjbpX88Y9862O5xhd0qlZtXIhYnm4Dvydy/knkVXHbxzJpYbhy6gR2lnr2uRjx5O1PwyNc0CZZQSf31VASwNs2FY2+BeGbiRRRO6Ff8FoWpfpYJigRGZL31r2HqnVC89mZhzFzlu7JWLy/a/csfcUsSgb4CAAA=
+  recorded_at: Thu, 20 Jan 2022 15:12:15 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email2@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:16 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '500'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RUY+iMBSF3/dXGJ5H04LMLCaTLCjVdQfEAuq42ZAKVYmFmhZcjfG/b6u7M2/70LQ99+vJ6b1XI29lwysqpDHo/LwaZaF2w16s19ESAxusfsAXByNnBazVszUPjCcjF5Q0tMhIo1ETmGYXwK4JEtgf2M7AhL2+aa0V2B6L/4Ma2pUnWmc1qaiGpnxfK3FLqpJdPtQRp0qkFSlZRopCUKnTPgTzGz2T6shoL+eVoj7r13/njJU1zaB+Es06Hj93oGW9fLKPuqnrIRfN/jeVjaoynhNWNhetT6ioC66jHblsCMtyXtyjQQCApZvC27oRdzaNjZvi9lyZ1m21oeLeUtvu6gWg4yhe0C0VtM5p9ug41NYf4iP+48NtLduNzEW5oZrcEibp7e8USl5nkrciv2dJJt/xKItcnLwrN0l3Fa0b5X8frRG8xT50v45gBBZhD/vucOJ6b77x68k4qfErK4WBm7rmrZD8Hnq4g2GCQhSkfh+P0DxA69l4fyRjd+f5+znxq0XzvmQyOHiMjlGTj8/srQpPm3jqDl0/jvzQwwvkpZUjltVRBOxwwQmaBQyBJMUhTaEdjLwZVqYJwiI42H68wiEGKVgmUxQAxycWm5HD4jlO0TSKua985+789dW4ffkD+OAJB74CAAA=
+  recorded_at: Thu, 20 Jan 2022 15:12:16 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/when_payment_source_is_not_captured/doesn_t_complete_the_payment.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_PaymentSyncService/_call/when_version_number_is_the_same_or_less_than_the_params/when_payment_source_is_not_captured/doesn_t_complete_the_payment.yml
@@ -100,4 +100,57 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAMVUXW/aMBR936+o/JxNmJJ28NYNirqNDmi6qEyTZZwLeEtsal9DUtT/PjvppD2gaUGaJkWKP8659/qcq3sg2mRgyODsQGTmf+T9Yy6vbiarcqGm40pX8+puvHzal4XoXZOI5FpwlFqxBv3pw9WsGyeT+ex8NAzXUgGTCIX1t18PxDWw8nr4Lvk4Gd2mizRJq3I9XX1XHv7ouEKJVcBQv1e8gLD+HIo6Q40896dLboFtjRTACq2gqqvlhXYK/ZLSTqcTEeGMASXqUPd3Q/IckbXR1jLLc7DtiHVihrw8RvsTJZNWBFhbXqvqdtzIxoOGfIIywSGG1bYW+yYZTcjzt4gUgDzjyOsoG20RMiY2IH5o58MRNA4CWRjg4YqHHKTb6dLX1H9xQnuD8/6Axm/it/HC++a22d8BLXpc7ft0dOv3OzDWvy88ISIGVhDqh5eWm/dp/5JeXlz0yH9wCuX2n5rbUCyYXTBVbLhZH/X2OFsBsgZia/gpBbTR8gQV2+h3mgyBqJ0RUEN/jRSrc5k5Pw78zDHAECyy31op9LWzqAswL322SOmGp/tyNv7Se0jpfjm+dw/dPvoEr34CDoZIjDcFAAA=
   recorded_at: Thu, 18 Nov 2021 14:27:53 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers/search
+    body:
+      encoding: UTF-8
+      string: '{"limit":1,"query":{"filter":{"email_address":{"fuzzy":"email4@example.com"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 15:12:19 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '497'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2RUW+bMBSF3/crIp6byCaglkiVBsEk6wINhpAm04QccAKSwcxAlirKf59NtvZtD5btcz8fH/tetaxvO15R0Wqz0Y+rVuZy1l6s5RaZxvzN37nh3Aged67ztHf2eKE9aJmgpKN5SjqF6kDXxwCOdRBDY2ZaM92aWKaxl2Df5P8HFXQqz7ROa1LR4WJe1FI8kqpk7x+qy6kUaUVKlpI8F7RVae+C8ZVeSNUwOsl4JanP+vXfOmVlTVOojqxfRw6/jOB0+vjJ3uu6qgdcdMVv2nayynhGWNm9K31JRZ1zFa3hbUdYmvF8iAYBAMoq433diYHdRNpNcgWXpnVfHahQqmmaYzUAtCzJC3qkgtYZTe8/DpX1h3iPf39wX7f9oc1EeaCKPBLW0tvfLpS8Tlvei2zIEi+/YTdd2zjeSbeWnipad9J/aK3mryIE7ScXrkESTDCy50vbWSHt54N2lu2XVhIDN7nNetHyIfT8BIPYCzx/gwzseqHv7V8XRUMW9slBRUhQlXS7LWsD5DC68LpscWGrKjgfohd7bqNojQIHJ56zqSwRM/z94DUofCuCBDGwTTD2GWt81wnkPI293KMI/iJTHGAEQLxtEn8Dl1GMFW9GG89bRxxJ39AOn5+125c/chjU774CAAA=
+  recorded_at: Thu, 20 Jan 2022 15:12:19 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_Payments_Create/_call/with_token_and_customer_id/creates_a_square_payment_with_the_correct_data.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_Payments_Create/_call/with_token_and_customer_id/creates_a_square_payment_with_the_correct_data.yml
@@ -1,0 +1,219 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers
+    body:
+      encoding: UTF-8
+      string: '{"given_name":"John","family_name":"Doe","email_address":"john.doe@gmail.com"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 13:54:53 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '234'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2P0WrCMBSG7/cUkutZ0qSi9GpCYZ2giJR19SbE5NRlNIkkjTCk777EjV16deD7v3MO/w2J4EerwaFydkNKxoHq125Fj8uiXbX7Jek+1rhu34sdrbboGQkHfATJ+JhUggmZ43xOcJPTclGUC5rlhB6jGC7ysZiks7qCYYZrSNLGfpoIe67V8P1PKwsRguZqYFxKB94n/BXlTFp4OackE1ZH6+KgBwdGgL8X+t0KxoeTF06dIBXs+eBh+quirGHeBifuv5r67VCx/frQdPHaFZyPeQzwND39AHlYG3UsAQAA
+  recorded_at: Thu, 20 Jan 2022 13:54:53 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"25635145542593","amount_money":{"amount":123,"currency":"USD"},"source_id":"cnon:card-nonce-ok","external_details":{"type":"CHECK","source":"Food
+        Delivery Service"},"autocomplete":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 13:54:53 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '759'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVUXXOaQBR976/I8NiJHb8QkzeC2FCjIKKp6XR2FvYad1wBlwXFTP57dzEkpplppk/KOfey95x7lictxeUWYqFdXzxplMgfjWRG6fArcWxGC8dfwX6KYw6jR7YkD0vtUos4YAEEYdWktZvtdqPZarSbQatzrXev9c63q57xIAvzlPyzsPutaeiqEG+TPBZom8RQVoOcAPm31e7IA3POIY4Upc1nA+35UssEFnmmANPzfHdhD+RrCDBcIpJzLGgSK9ILWr3+raSyJOcRIFGmoHDL9FVDhDlBBASmLKvOPXvtPLh1fefBrusqvmoIOY4roxbOzJQsw5lAXQXofb0vATikSotYKwGnxxIwl0/Sg+6ltqLxI/CU00qilu0arcYPN5iytrE29CALnDwxRkfSwLd+wMh4le2d3sN+T5bEtR+NxsYM7s0VN71V/xAeXKszbCFvWut51ejbAyeQaMohxfSNmLgB8nzbMx2lLaSVU1290zZ0Za0MAy/RFsQ6qVSO7OXJhKJAb/5YiwUyLcv2gorERXZGmovZOakIUCGTXmcRp2m9ntn04uvAHprzu+AisGfBhWxy55OglvKSTSToFhiN4ZSNXE7G6fHzYD1LNSyJqjSgU7bvvk/8bsdazoY/lwt5TMIJ8BeuuHLGa7rt6pMC1sMRhnK6+WFCMg3DKvecZhsEBWZ5na+nT+/Ca8SrZgYFsNMK/LF5p9wWicDsf5KP05QnhTzyP3oinOKQMiooqP380lQykDlWXqO5J8c7Bwbu/aSGAsf7WHcGVrW/pTyIQO4Vxfk2BF5/RV7vJI7qlVvmxLLvakLKkJNT9s4848OHRGpm9GWP767rLscckDSE5FG1Adtyx2Pbt2xkes5fnactZ/Lyhsmhke2alIQNJ+oZx+NqMyupVe5H/V16PLh7ZVoBPFNtItlANTqL8sHt3F/vepHObtaHCemQmx2bcRiODqv7bniM7NZ84wwej71Ehu/LH76M5mtdBQAA
+  recorded_at: Thu, 20 Jan 2022 13:54:54 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/cards
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"768146277285702","source_id":"ds7yIr9tz0cVIRfewQanreKglYdZY","card":{"customer_id":"HGY83Z74W8WP72YXA0HWV4N3DM","cardholder_name":"John
+        Doe"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Speleo-Traceid:
+      - ARYjkFRQRbdaG
+      X-Xss-Protection:
+      - 1; mode=block
+      Date:
+      - Thu, 20 Jan 2022 13:54:54 GMT
+      Content-Length:
+      - '323'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAA/ySQy86bMBBGX6WaNUjG2IV6R/u3fy5KcykNDRvLYBNoHZvaREkT5d0rJ8uRjj6dM3dohZPA7jBIYNC2tmMI7bYor2/D7+XY/ix68v4ZoifHGydM4PbzHwVEoIWfOAEGNKc5RKCuIz9ZM/XAktf1TwkHDCNMXgu91VI5bsRJAYOF7c2HN6sggmbQejBHLqR0yvtgNFo/Cc1bKwP7iSQohUcE3WCOyo1uMBMw8H/jJF6sy63GWZ/R0pfzs82WNxmL2a7UctX5y/xjfbnIg1x/PWbxn6Ksis4Vmy6/Ntf1l/RbwjfbEHj2kz0px5+fmL0f8rTOSJVXmwwffhVoVu3J9/RtFTqNaLSSwCZ3VsHdAANCU5zRMOSUmJTkIvhhhHGMkhijMkkZJYzSGh6P/wEAAP//FXY7/HgBAAA=
+  recorded_at: Thu, 20 Jan 2022 13:54:54 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"a1a70a7d-1b7f-40e4-ad39-6c5c0d2f519a","source_id":"ccof:00RQ08ZzijKpcUAh4GB","amount_money":{"amount":1999,"currency":"USD"},"autocomplete":false,"customer_id":"HGY83Z74W8WP72YXA0HWV4N3DM"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Jan 2022 13:54:55 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '801'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVUUZOaOhR+v79ih8c76x1REHbfKGKloiAirHY6mQhxTUWCSVBxp//9Jrhst+1D2yflfOecnO87X/KilLA+oIIrj3cvCs7Ej/LkEbMKul/rnldje1TuXFUN60mWXubrlXKvpBRBjjIAZZHS6/Z6na7a6XUjtf+oa4+6/t+gb65FYlVmv0k0tIFMhAdSFRwcSIHqZpBbQPxVHx4exIkVpahIJaYsF0Pl273COOQVkwErCEI/doaiT4ZyWIOsopBjUkgwiNSBORYQIxVNEeB1iWTctkJZkEKagQxxiHPWHPyu7TIa+6G7dtq8Bm8KNhQWjVKxu7AEmkPGgSYDuqmbIoAupSTDd5LB7bNGkIovIYJ2r2xx8YxoSXHDUWHHjtr55EfzvGfsDD1ikVsRY3LNOnAcRnk23bKzO1ifz9kq851no7O3osTaUivYmpfNxbf7IxUE85bPG8fQGbqRiJYUlRB/B2Z+BILQCSxXctvgRilN7/cMXUor3EBrcEB8RxqW/gyMXM+R7U8n8F0hO46BbGWPHXvSyARP7B1uxQtg2bYTRA0oASStJgRnKcVlu6PF/O7foTOyll50FzmL6E4U+ctZ1PJ5dSjg+IByXKCbQyoxHsXX39vrm6CUk7SxBLg53Ps4C7W+vVqMnlaxOIbQDNFXLEazmHzSTyy5kuKZ6/0zWa2varoZu437KWZ7gE4wr1qTvfzBjXg1elOcoxPKb3sIp5YnJU8rxsnhbYbxx5XZXxtaYiaB0Vs9Wd1xEmuz/nAqenDCYf5XdwWWJSUnMd/fFKWwhBucY46R3OZnRZoJWFO5GbAMxCDvA0M/mbWhyA1+zXsXbHK/CDFQioQLQFEdNoi2L8/bNYZpaxDbmtmO1wKChxgd5z9Ibfzy+AjSOX7d+g83/FhBioBQJKvSZl+O7U+nTmg7wArcnypv+2Divm/IpcOOXZxtOm46MK7X7X4hnsf6PDGP5fXin6VoJ0SZLONkj5rRiZeqmfHgJUzLvbmq6pPuDu6T4W6ULj/skzXE5bE2WK6djwMirPrP/5n3IDmRBQAA
+  recorded_at: Thu, 20 Jan 2022 13:54:55 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusSquare_Payments_Create/_call/with_token_and_customer_id/creates_the_payment_from_the_card_and_the_customer.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusSquare_Payments_Create/_call/with_token_and_customer_id/creates_the_payment_from_the_card_and_the_customer.yml
@@ -1,0 +1,219 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/customers
+    body:
+      encoding: UTF-8
+      string: '{"given_name":"John","family_name":"Doe","email_address":"john.doe@gmail.com"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jan 2022 21:39:03 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '233'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAH2PsW7CMBCG9z5F5blEtpMBMjUVBcqAaBSJlMUy9gWMYhvZMVKF8u61adWR6aTv/+5O/w2J4AerwaHy+YaUjANt9otdsWyrVd22b+8ET4vPXZHTaovRCxIO+ACS8SGpFFM6wWRCZg0lZT4rcZ5NyT564SIfe0k6qisYZriGJK3tyUTYca367386txAhaK56xqV04H3C5yhn0sLrMSWZsDpaFwcdODAC/L3P71YwPhy8cOoAqV/Hew/jXxNlDfM2OHH/1aw+6jnbVnXzFa9dwfmYxwCP49MP5NWM2CsBAAA=
+  recorded_at: Wed, 19 Jan 2022 21:39:03 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"337630216507473","amount_money":{"amount":123,"currency":"USD"},"source_id":"cnon:card-nonce-ok","external_details":{"type":"CHECK","source":"Food
+        Delivery Service"},"autocomplete":false}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jan 2022 21:39:04 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '762'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVUXXOiMBR931/R4XGn7ohf2L5RxMqqgBC1urOTiRBsagQMQcVO//smWFp3+9Dtk3LOveSec094VlJUbHHMldurZ4WE4kd5ArNtoKVP9Xr/cR6pczPN71z32J0couVCuVYChhHHIUSySWnUG41aXa2pN6Ch3jZvbuutH52OthSFeRp+UqhpbVmItkkec7hNYlyUg5wB8VdtNMWBOWM4DiSlTP2e8nKtZBzxPJOA7rqeMzN74jUhpqiAYc4QJ0ksSReone5AUFmSswBDXqRY4obuyYYAsRCGmCNCs/Lci9dOwcDxrKVZ1ZV82bBiKC6Nmlm+LliKMg5bEmh3210B4GMqtfBHKeD8WGDExJPwoHWtRCReY5YyUkpUsl1Nrf10wIQ2tEetDTJg5Yk2PIU1NPAADcdRdrA6y8MhXISOudZqGx3M9YjpbtQ9ro6O0eyr0J1Uet40embPAgJNGU4ReSdsB0DXM13dktpWpHSq1W42tLa0VoSBFXCL+WNSqhyai7MJ+z1898eYzaBuGKYLShLtswtSn/mXpCSwDJnwOgsYSav1+JOr7z2zr09H4AqYPrgSTc7UBpWU12xCTraYkhifs5GLyRg5fR6sF6GGJkGZBnjO9uje9lpNY+H3HxYzcUzCQsxeOb4YDtXmjE7u152oNbopis76cIrsjb8oc89ItoF4j2he5ev5P+7Ca8TLZor3mJ5X4I31kXSbJxzRryQfpSlL9uLIL/QEKEUrQgknWO7nlyKTAfWx9BpOXTHeJdBz5nYFAcv9WHcBlrW/hTwcYLFXGOfbFWbVV+TtTqKgWrmh24Y5qgghQ0xO6KV5jc6HD4nQTMnrHv+6rrscMQyFIWEelBswDWc8Nj3DhLpr/dN53nImLu8qOdayXZ2Eq5oVdLTTKdr4BTGKw7C7S09H5yBN22OWyTaebHA5uj5e756md5nfo+FDfbA5pI53Qx/ovDW13aHejvjpbntvHwd2q52I8H37A2dRXBRdBQAA
+  recorded_at: Wed, 19 Jan 2022 21:39:04 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/cards
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"138694918332517","source_id":"jTVmc7pj00FhWf1WEpuBPPx8QwfZY","card":{"customer_id":"NZFW4GXAHRXXBE1084QW432AP0","cardholder_name":"John
+        Doe"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Speleo-Traceid:
+      - KceAZCXMZdghG
+      X-Xss-Protection:
+      - 1; mode=block
+      Date:
+      - Wed, 19 Jan 2022 21:39:05 GMT
+      Content-Length:
+      - '322'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAA/ySQyc6bMBRGX6W6a5CwgUC8I2kmqjZDUQY2lsEmoBo7tYlCG+XdfzlZXuno0zn3CTUzHMgTOg4E6lo3JJ1f8n7sqjU66uKSl+FqBt6bo5VhynHHze8MPJDMDjQCAnEap+CBGG+012pogaDP9U8wAwQHOPostFpyYahivQACuW7Vt+9agAdVJ2WnrpRxboS1zuim7cAkrTV37DRCQQgvD5pOXYW5mU4NQMD+9ZGfb4u9xEmbxIUtNned/PjPfbY+FJL/bOxjMykfD37h28U18f9kxSlrTLZr0rEat/Nwiehu7wLvdtC9MPT9iV/l8hStztn6cD7PFihIo/0pCnG2C1ynYpUUHMhg7sK5KyAQxSFOYjdkBBsEp8z54QBjP0A+mhYYkXBKgkkJr9dXAAAA//+gDjGJeAEAAA==
+  recorded_at: Wed, 19 Jan 2022 21:39:05 GMT
+- request:
+    method: post
+    uri: https://connect.squareupsandbox.com/v2/payments
+    body:
+      encoding: UTF-8
+      string: '{"idempotency_key":"3872cdce-df13-4526-9958-9a89c525c735","source_id":"ccof:8CYJmxibH1VoTYJZ3GB","amount_money":{"amount":1999,"currency":"USD"},"autocomplete":false,"customer_id":"NZFW4GXAHRXXBE1084QW432AP0"}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json; charset=utf-8
+      Authorization:
+      - "<BEARER_TOKEN>"
+      User-Agent:
+      - Square-Ruby-SDK/14.1.0.20210915
+      Square-Version:
+      - '2021-09-15'
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Jan 2022 21:39:14 GMT
+      Frame-Options:
+      - DENY
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - application/json
+      Square-Version:
+      - '2021-09-15'
+      Squareup--Connect--V2--Common--Versionmetadata-Bin:
+      - CgoyMDIxLTA5LTE1
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '801'
+      Strict-Transport-Security:
+      - max-age=631152000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAJVUXXObOhB9v78iw+Od+I6xscF5IxjH1NhgkD87HY0AOVHDl4XAxpn+9yvhkLrtQ9snYM/uas/ZI96kHNUJTpn0cPcmkYg/pFSdsanqLuOhvfgayCWwutpYi5xkO9rtpHsppBgxHEEkiqRet9frdOWOPAI9+aE/epCV/waavOeJZR79JnE4ahJRkpUpg0mW4roZ5Brgr/JoNOInlpTiNBSYtPLH0rd7qWCIlYUI6K7rOWtzzPtEOEY1jEqKGMlSAbpAHmpTDhVZSUMMWZ1jETd0TxSEiEYwwgyRuGgOvmm7AlPHs/Zmm9fgTUFAUdootbZ8naMxKhhURGCgDTQewOdckGEvgsH1s8aI8i8ugnIvHUj6jGlOScNRKo4dufPJAcu4p76oA1AAq8zU2SXqoKkH4mh+KE7WcH86RbvIMZ/VzqsONvqB6u5BOwdnx+hPZOguWz4fHD1zbAEezSnOEfkOLBwAXc90dUtwC0ijlDLo99SBkJa7gdYwwewla1g6CzixbFO0ryr4XSFjvYailTE1jVkjE6qKG1xf+1A3DNMFDSgALKzGBS9CSvJ2R/7y7t+xOdFXNrgDpg/ueJGzWoCWz7tDISMJjkmKrw4p+XiUXH5vr2+cUpyFjSXg1eH208JT+sbOn2x3a35MRiNM37GxjZUZju308jWbjsl8fRl1H/0yqSK0F+6npHiFuEJx2Zrs7Q9uxLvRm+IYVzi+7sGb67aQPCwLliUfMyz2k43ytNWn3nb7aMpdTVlulH5Pd7u8B8sYiv/qrqA8p1nF5/ubohDlKCAxYQSLbX6WhJmgPhebgSuXD3IbGDubRRsClvtr3k2wyf3CxcAh5i6AaZkEmLZ/no9rjMLWIIa+MEy7BTgPPjqJb6XuDX/5+XDSMXnf+g83/FgiiiFXJCrDZl+m4cznpmeYUHetnyqv+yj4fQ+yc6c4dkkUdKxwqF4uh1e/JkZ9mmnH/HJ2TkK0CtNClLHsFTej26WNqr1SJUdtpm4CP7GevA1LHi/xYwXYcxGQnVqbkyjqs2HGrfrP/+e254GRBQAA
+  recorded_at: Wed, 19 Jan 2022 21:39:14 GMT
+recorded_with: VCR 6.0.0

--- a/spec/models/solidus_square/customer_spec.rb
+++ b/spec/models/solidus_square/customer_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusSquare::Customer, type: :model do
+  it { is_expected.to belong_to(:user).class_name('Spree::User') }
+end

--- a/spec/models/solidus_square/gateway_spec.rb
+++ b/spec/models/solidus_square/gateway_spec.rb
@@ -224,6 +224,29 @@ RSpec.describe SolidusSquare::Gateway do
       end
     end
 
+    context 'when the user is guest' do
+      before do
+        allow(gateway).to receive(:create_payment).with(123, 'nonce', nil, nil).and_return(square_response)
+        payment.order.user.delete
+        payment.order.reload
+      end
+
+      it 'does not call the SolidusSquare::Cards::Create service' do
+        method
+
+        expect(SolidusSquare::Cards::Create).not_to have_received(:call)
+      end
+
+      it "returns a successfull response" do
+        expect(method).to be_success
+      end
+
+      it "updates the payment response code" do
+        method
+        expect(payment.response_code).to eq '123'
+      end
+    end
+
     context 'when the payment_source contains token and customer_id' do
       let(:payment_source) do
         create(:square_payment_source, nonce: 'nonce', token: 'token', customer_id: 'customer_id')

--- a/spec/models/solidus_square/gateway_spec.rb
+++ b/spec/models/solidus_square/gateway_spec.rb
@@ -226,6 +226,16 @@ RSpec.describe SolidusSquare::Gateway do
       end
     end
 
+    context 'when Spree::PaymentMethod#payment_profiles_supported? is false' do
+      before { allow(payment.payment_method).to receive(:payment_profiles_supported?).and_return(false) }
+
+      it 'does not call the SolidusSquare::Cards::Create service' do
+        method
+
+        expect(SolidusSquare::Cards::Create).not_to have_received(:call)
+      end
+    end
+
     context 'when the user is guest' do
       before do
         payment.order.user.delete

--- a/spec/models/solidus_square/gateway_spec.rb
+++ b/spec/models/solidus_square/gateway_spec.rb
@@ -176,13 +176,14 @@ RSpec.describe SolidusSquare::Gateway do
   RSpec.shared_examples "#create_payment_on_square" do
     before do
       allow(SolidusSquare::Cards::Create).to receive(:call).and_return(id: 'token-card-id')
+      allow(gateway).to receive(:create_payment).with(123, 'nonce', nil).and_return(square_response)
+      allow(gateway).to receive(:create_payment).with(123, 'nonce', nil, nil).and_return(square_response)
     end
 
     context "when valid" do
       let(:customer_id) { 'sq-customer-id' }
 
       before do
-        allow(gateway).to receive(:create_payment).with(123, 'nonce', nil, nil).and_return(square_response)
         payment.order.user.create_square_customer(square_customer_ref: customer_id)
       end
 
@@ -215,6 +216,7 @@ RSpec.describe SolidusSquare::Gateway do
 
     context "when not valid" do
       before do
+        allow(gateway).to receive(:create_payment).with(123, 'nonce', nil).and_raise(StandardError, "test error")
         allow(gateway).to receive(:create_payment).with(123, 'nonce', nil, nil).and_raise(StandardError, "test error")
       end
 
@@ -226,7 +228,6 @@ RSpec.describe SolidusSquare::Gateway do
 
     context 'when the user is guest' do
       before do
-        allow(gateway).to receive(:create_payment).with(123, 'nonce', nil, nil).and_return(square_response)
         payment.order.user.delete
         payment.order.reload
       end

--- a/spec/models/solidus_square/payment_method_spec.rb
+++ b/spec/models/solidus_square/payment_method_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusSquare::PaymentMethod, type: :model do
+  it { is_expected.to delegate_method(:create_profile).to(:gateway) }
+
+  describe '#payment_profiles_supported?' do
+    it 'return true' do
+      expect(described_class.new).to be_payment_profiles_supported
+    end
+  end
+end

--- a/spec/models/solidus_square/payment_source_spec.rb
+++ b/spec/models/solidus_square/payment_source_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe SolidusSquare::PaymentSource, type: :model do
   let(:payment) { instance_double(Spree::Payment) }
   let(:gateway) { instance_double(SolidusSquare::Gateway) }
 
+  it { is_expected.to belong_to(:customer).class_name('SolidusSquare::Customer').optional }
+
   describe "#can_void?" do
     subject(:can_void?) { payment_source.can_void?(payment) }
 

--- a/spec/models/solidus_square/payment_source_spec.rb
+++ b/spec/models/solidus_square/payment_source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SolidusSquare::PaymentSource, type: :model do
@@ -45,6 +47,12 @@ RSpec.describe SolidusSquare::PaymentSource, type: :model do
       let(:status) { "AUTHORIZED" }
 
       it { expect(payment_source).not_to be_captured }
+    end
+  end
+
+  describe '#reusable?' do
+    it 'return true' do
+      expect(described_class.new).to be_reusable
     end
   end
 end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::User, type: :model do
+  it { is_expected.to have_one(:square_customer).class_name('SolidusSquare::Customer') }
+end

--- a/spec/presenters/solidus_square/payment_source_presenter_spec.rb
+++ b/spec/presenters/solidus_square/payment_source_presenter_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe SolidusSquare::PaymentSourcePresenter do
         last_digits: "9029",
         card_brand: "MASTERCARD",
         card_type: "CREDIT",
-        status: "CAPTURED",
-        token: 12
+        status: "CAPTURED"
       }
     end
 

--- a/spec/services/solidus_square/cards/create_spec.rb
+++ b/spec/services/solidus_square/cards/create_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ::SolidusSquare::Cards::Create do
+  subject(:service) do
+    described_class.call({ client: client, source_id: source_id, bill_address: bill_address, customer_id: customer_id })
+  end
+
+  let(:source_id) { create_authorized_square_payment_id_on_sandbox(source_id: 'cnon:card-nonce-ok') }
+  let(:customer_id) { create_customer_id_on_sandbox }
+  let(:spree_user) { create(:user_with_addresses) }
+  let(:bill_address) { spree_user.addresses.first }
+  let(:client) do
+    ::Square::Client.new(
+      access_token: SolidusSquare.config.square_access_token,
+      environment: "sandbox"
+    )
+  end
+
+  it 'Creates the Card on square', :vcr do
+    expect(service).to match hash_including(
+      :id, :card_brand, :customer_id, enabled: true, cardholder_name: bill_address.name
+    )
+  end
+end

--- a/spec/services/solidus_square/payment_sync_service_spec.rb
+++ b/spec/services/solidus_square/payment_sync_service_spec.rb
@@ -3,11 +3,13 @@
 RSpec.describe SolidusSquare::PaymentSyncService do
   subject(:handler) { described_class.new(params) }
 
-  let(:options) {
-    { access_token: ENV['SQUARE_ACCESS_TOKEN'] || "abcde", environment: 'sandbox',
-      location_id: ENV['SQUARE_LOCATION_ID'] || 'location' }
-  }
-  let(:payment_method) { create(:square_payment_method) }
+  let(:options) do
+    {
+      access_token: SolidusSquare.config.square_access_token,
+      environment: "sandbox"
+    }
+  end
+  let(:payment_method) { create(:square_payment_method, preferences: options) }
   let(:gateway) { SolidusSquare::Gateway.new(options) }
   let!(:order) { create(:order_ready_to_complete, number: "R919717664", state: 'payment', payment_state: nil) }
   let(:square_order_id) { find_or_create_square_order_id_on_sandbox(order: order, hosted_checkout: true) }
@@ -24,7 +26,6 @@ RSpec.describe SolidusSquare::PaymentSyncService do
   end
 
   before do
-    allow(payment_method).to receive(:gateway).and_return(gateway)
     allow(SolidusSquare.config).to receive(:square_payment_method).and_return(payment_method)
   end
 

--- a/spec/services/solidus_square/payments/create_spec.rb
+++ b/spec/services/solidus_square/payments/create_spec.rb
@@ -2,8 +2,10 @@
 
 RSpec.describe SolidusSquare::Payments::Create, type: :request do
   subject(:create_payment) {
-    described_class.new(client: client, source_id: "nonce", amount: 19.99, auto_capture: false)
+    described_class.new(client: client, source_id: source_id, amount: 19.99, auto_capture: false)
   }
+
+  let(:source_id) { 'nonce' }
 
   let(:client) do
     ::Square::Client.new(
@@ -36,6 +38,22 @@ RSpec.describe SolidusSquare::Payments::Create, type: :request do
 
     it "creates a square payment with the correct data" do
       expect(create_payment.call[:amount_money]).to match({ amount: 1999, currency: "USD" })
+    end
+
+    context 'with token and customer_id' do
+      subject(:create_payment) do
+        described_class.new(
+          client: client, source_id: source_id, amount: 1999, auto_capture: false,
+          customer_id: customer_id
+        )
+      end
+
+      let(:customer_id) { create_customer_id_on_sandbox }
+      let(:source_id) { create_card_id_on_sandbox(customer_id: customer_id) }
+
+      it "creates a square payment with the correct data" do
+        expect(create_payment.call[:amount_money]).to match({ amount: 1999, currency: "USD" })
+      end
     end
   end
 end

--- a/spec/support/square.rb
+++ b/spec/support/square.rb
@@ -66,12 +66,24 @@ module SquareHelpers
     }
   end
 
-  def create_authorized_square_payment_id_on_sandbox
+  def create_customer_id_on_sandbox
     client = ::Square::Client.new(
       access_token: SolidusSquare.config.square_access_token,
       environment: "sandbox"
     )
-    client.payments.create_payment(body: create_payment_payload).data.payment[:id]
+    client.customers.create_customer(body: {
+      given_name: 'John',
+      family_name: 'Doe',
+      email_address: 'john.doe@gmail.com',
+    }).data.customer[:id]
+  end
+
+  def create_authorized_square_payment_id_on_sandbox(source_id: nil)
+    client = ::Square::Client.new(
+      access_token: SolidusSquare.config.square_access_token,
+      environment: "sandbox"
+    )
+    client.payments.create_payment(body: create_payment_payload(source_id: source_id)).data.payment[:id]
   end
 
   def create_and_capture_payment_on_sandbox
@@ -83,14 +95,14 @@ module SquareHelpers
     client.payments.complete_payment(payment_id: create_authorized_square_payment_id_on_sandbox).body.payment
   end
 
-  def create_payment_payload
+  def create_payment_payload(source_id: 'EXTERNAL')
     external_details = { type: "CHECK", source: "Food Delivery Service" }
     idempotency_key = rand(1_000_000_000_000_000).to_s
     amount_money = { amount: 123, currency: "USD" }
     {
       idempotency_key: idempotency_key,
       amount_money: amount_money,
-      source_id: "EXTERNAL",
+      source_id: source_id,
       external_details: external_details,
       autocomplete: false
     }

--- a/spec/support/square.rb
+++ b/spec/support/square.rb
@@ -66,6 +66,24 @@ module SquareHelpers
     }
   end
 
+  def create_card_id_on_sandbox(customer_id: nil, source_id: 'cnon:card-nonce-ok')
+    customer_id = create_customer_id_on_sandbox if customer_id.nil?
+    payment_token = create_authorized_square_payment_id_on_sandbox(source_id: source_id)
+
+    client = ::Square::Client.new(
+      access_token: SolidusSquare.config.square_access_token,
+      environment: "sandbox"
+    )
+    client.cards.create_card(body: {
+      idempotency_key: rand(1_000_000_000_000_000).to_s,
+      source_id: payment_token,
+      card: {
+        customer_id: customer_id,
+        cardholder_name: 'John Doe'
+      }
+    }).data.card[:id]
+  end
+
   def create_customer_id_on_sandbox
     client = ::Square::Client.new(
       access_token: SolidusSquare.config.square_access_token,


### PR DESCRIPTION
Save the card on Square in order to re-use it for the subscription.

Following the instruction specified on [Square Documentation](https://developer.squareup.com/docs/cards-api/walkthrough/card-from-payment-id) this PR does:

- Create the customer on Square when the payment is saved. ref https://github.com/solidusio/solidus/blob/e878076f2ed670d07654ab6293a16588743f2fa6/core/app/models/spree/payment.rb#L201
- If SolidusSquare::PaymentSource#token is empty, save the card to square and store its ID on the token ref https://github.com/nebulab/solidus_square/pull/69/files#diff-1bafe74d854b0b95c82a0db695d314b51be7e18315a0a990f400bf1df69b81fcR144-R147
- if SolidusSquare::PaymentSource#token is present, use token and customer_id to create the payment ref https://github.com/nebulab/solidus_square/pull/69/files#diff-1bafe74d854b0b95c82a0db695d314b51be7e18315a0a990f400bf1df69b81fcR137

I have QA it with:

both new and existing card
auto capture enabled and disabled
Guest user

<details>
  <summary>Details</summary>
  
  New card
<img width="722" alt="Screenshot 2022-01-20 at 16 38 34" src="https://user-images.githubusercontent.com/387690/150377020-0fdc904f-3b24-4b84-b500-c1c0819b0861.png">

Existing card
<img width="724" alt="Screenshot 2022-01-20 at 16 39 31" src="https://user-images.githubusercontent.com/387690/150377027-05d09bba-b21c-4a27-b8c7-c6ddc79c1e18.png">

Guest user
<img width="983" alt="Screenshot 2022-01-20 at 16 40 24" src="https://user-images.githubusercontent.com/387690/150377317-523118fe-f159-42a7-9ee6-1c00d687a506.png">

Auto capture false
<img width="1131" alt="Screenshot 2022-01-20 at 16 34 43" src="https://user-images.githubusercontent.com/387690/150377538-06246c01-8b93-45b6-8c30-90a32242d361.png">
<img width="1151" alt="Screenshot 2022-01-20 at 16 34 54" src="https://user-images.githubusercontent.com/387690/150377551-dd51b113-dc47-44c5-99cc-84c231645ee0.png">
</details>

