### PR TITLE
Fix customer_id problem

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -73,7 +73,7 @@ module SolidusSquare
       )
     end
 
-    def create_payment(amount, source_id, auto_capture, customer_id)
+    def create_payment(amount, source_id, auto_capture, customer_id = nil)
       ::SolidusSquare::Payments::Create.call(
         client: client,
         amount: amount,


### PR DESCRIPTION
There was an error around line 146 than prevents to run create_payment
with 3 args.
The spec didn't fail because the method was stubbed.
This commit, adds the default valud when the arg is missing, and one
regression test for it.