### PR TITLE
Add Spree::PaymentMethod#try_void

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -27,7 +27,15 @@ module SolidusSquare
       ActiveMerchant::Billing::Response.new(true, 'Transaction captured', response, authorization: response_code)
     end
 
-    def credit(amount, response_code, _options)
+    def credit(*args)
+      payment = args.last[:originator].try(:payment)
+
+      if payment.payment_method.payment_profiles_supported?
+        amount, _source, response_code, _options = args
+      else
+        amount, response_code, _options = args
+      end
+
       response = refund_payment(amount, response_code)
 
       ActiveMerchant::Billing::Response.new(true, "Transaction Credited with #{amount}", response,

--- a/app/models/solidus_square/payment_method.rb
+++ b/app/models/solidus_square/payment_method.rb
@@ -27,5 +27,11 @@ module SolidusSquare
     def partial_name
       "square"
     end
+
+    def try_void(payment)
+      return false unless payment.source.can_void?(payment)
+
+      gateway.void(payment.response_code, originator: payment)
+    end
   end
 end

--- a/spec/models/solidus_square/gateway_spec.rb
+++ b/spec/models/solidus_square/gateway_spec.rb
@@ -130,6 +130,18 @@ RSpec.describe SolidusSquare::Gateway do
     it "returns a successfull response" do
       expect(credit).to be_success
     end
+
+    context 'when called with 4 parameters' do
+      subject(:credit) { gateway.credit(123, payment.source, "response_code", gateway_options) }
+
+      it "returns an ActiveMerchant::Billing::Response " do
+        expect(credit).to be_an_instance_of(ActiveMerchant::Billing::Response)
+      end
+
+      it "returns a successfull response" do
+        expect(credit).to be_success
+      end
+    end
   end
 
   describe '#cancel_payment' do

--- a/spec/models/solidus_square/payment_method_spec.rb
+++ b/spec/models/solidus_square/payment_method_spec.rb
@@ -10,4 +10,29 @@ RSpec.describe SolidusSquare::PaymentMethod, type: :model do
       expect(described_class.new).to be_payment_profiles_supported
     end
   end
+
+  describe '#try_void' do
+    let(:payment) { create(:payment) }
+
+    context 'when the payment cannot be voided' do
+      subject(:try_void) { described_instance.try_void(payment) }
+
+      let(:described_instance) { described_class.new }
+      let(:response) { ActiveMerchant::Billing::Response.new(true, 'Transaction voided', {}, authorization: '123') }
+
+      before do
+        allow(payment.source).to receive(:can_void?).and_return(true)
+        allow(described_instance.gateway).to receive(:void).and_return(response)
+      end
+
+      it 'calls void on the gateway' do
+        try_void
+
+        expect(described_instance.gateway).to have_received(:void).with(
+          payment.response_code,
+          originator: payment
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Before this PR order cancellation failed with:

```
You need to implement `try_void` for SolidusSquare::PaymentMethod. In that return a ActiveMerchant::Billing::Response object if the void succeeds or `false|nil` if the void is not possible anymore. Solidus will refund the amount of the payment then.
```

Implementing `try_void` allowed me to cancel the order and the payment for both `void` and `credit` now