### PR TITLE
Provide order number when creating payment

### DIFF
--- a/app/models/solidus_square/gateway.rb
+++ b/app/models/solidus_square/gateway.rb
@@ -81,13 +81,14 @@ module SolidusSquare
       )
     end
 
-    def create_payment(amount, source_id, auto_capture, customer_id = nil)
+    def create_payment(amount, source_id, auto_capture, customer_id = nil, order_number = nil)
       ::SolidusSquare::Payments::Create.call(
         client: client,
         amount: amount,
         source_id: source_id,
         auto_capture: auto_capture,
-        customer_id: customer_id
+        customer_id: customer_id,
+        order_number: order_number
       )
     end
 
@@ -148,10 +149,10 @@ module SolidusSquare
       if payment_source.token
         source_id = payment_source.token
         customer_id = square_customer_ref(order)
-        square_payment = create_payment(amount, source_id, auto_capture, customer_id)
+        square_payment = create_payment(amount, source_id, auto_capture, customer_id, order.number)
       else
         source_id = payment_source.nonce
-        square_payment = create_payment(amount, source_id, auto_capture)
+        square_payment = create_payment(amount, source_id, auto_capture, nil, order.number)
 
         if payment.payment_method.payment_profiles_supported? && order.user.present?
           card = create_card(square_payment[:id], order.bill_address, square_customer_ref(order))

--- a/app/services/solidus_square/payments/create.rb
+++ b/app/services/solidus_square/payments/create.rb
@@ -3,12 +3,13 @@
 module SolidusSquare
   module Payments
     class Create < ::SolidusSquare::Base
-      def initialize(client:, source_id:, amount:, auto_capture:, customer_id: nil)
+      def initialize(client:, source_id:, amount:, auto_capture:, customer_id: nil, order_number: nil)
         @client = client
         @source_id = source_id
         @amount = amount
         @auto_capture = auto_capture ? true : false
         @customer_id = customer_id
+        @order_number = order_number
 
         super
       end
@@ -19,7 +20,7 @@ module SolidusSquare
 
       private
 
-      attr_reader :client, :source_id, :amount, :auto_capture, :customer_id
+      attr_reader :client, :source_id, :amount, :auto_capture, :customer_id, :order_number
 
       def create_payment
         handle_square_result(client.payments.create_payment(body: payment_payload)) do |result|
@@ -36,6 +37,7 @@ module SolidusSquare
             currency: "USD"
           },
           autocomplete: auto_capture,
+          note: order_number 
         }.merge(customer_params)
       end
 


### PR DESCRIPTION
Provide order number as a note when creating a payment. So that it's displayed in square dashboard and merchants can easily identify which order payment belongs to.

See https://developer.squareup.com/reference/square_2021-09-15/payments-api/create-payment#request__property-note

<img width="1427" alt="191838896-04bea34b-39ee-42f6-9016-983ff5b37492" src="https://user-images.githubusercontent.com/245662/191992587-e716d006-d043-48ac-8bac-ffb41a7cad74.png">
